### PR TITLE
feat(images): add LQIP placeholders (dominant_color + blur_data_url)

### DIFF
--- a/app/routers/upload.py
+++ b/app/routers/upload.py
@@ -24,6 +24,7 @@ from fastapi import (
 from app.config import settings
 from app.routers.auth import require_scopes
 from app.routers.utils import (
+    CustomImageParams,
     _image_response,
     _read_capped,
     _sanitize_extension,
@@ -89,15 +90,9 @@ class _ProcessedImageData:
     height: int
     renditions_buffers: dict[str, bytes]
     content_hash: str
+    dominant_color: str | None = None
+    blur_data_url: str | None = None
     original_filename: str | None = None
-
-
-@dataclass(frozen=True)
-class _CustomImageParams:
-    width: int | None = None
-    height: int | None = None
-    fit: str = "auto"
-    format: str | None = None
 
 
 _ALLOWED_VIDEO_CONTENT_TYPES = frozenset(
@@ -200,12 +195,15 @@ async def _process_single_image(
                 existing.storage_key,
                 renditions=existing.renditions,
                 include_thumbnail=thumbnail,
-                custom_width=width,
-                custom_height=height,
-                custom_fit=fit,
-                custom_format=format,
+                custom_params=CustomImageParams(
+                    width=width,
+                    height=height,
+                    fit=fit,
+                    format=format,
+                ),
                 visibility=existing.visibility,
                 original_filename=original_filename,
+                placeholders=(existing.dominant_color, existing.blur_data_url),
             )
 
         # Client-side failures (bad/unsupported image) => 400, generic detail.
@@ -239,9 +237,11 @@ async def _process_single_image(
             height=processed.height,
             renditions_buffers=processed.renditions,
             content_hash=content_hash,
+            dominant_color=processed.dominant_color,
+            blur_data_url=processed.blur_data_url,
             original_filename=original_filename,
         )
-        custom_params = _CustomImageParams(
+        custom_params = CustomImageParams(
             width=width,
             height=height,
             fit=fit,
@@ -334,6 +334,8 @@ async def _create_image_record(
             content_hash=img_data.content_hash,
             visibility=visibility,
             renditions=renditions_dict,
+            dominant_color=img_data.dominant_color,
+            blur_data_url=img_data.blur_data_url,
             original_filename=img_data.original_filename,
         )
     except MetadataError as exc:
@@ -351,7 +353,7 @@ async def _store_and_record_image(
     owner: str,
     object_name: str,
     img_data: _ProcessedImageData,
-    custom_params: _CustomImageParams,
+    custom_params: CustomImageParams,
     *,
     include_thumbnail: bool = False,
     visibility: str = "public",
@@ -396,12 +398,10 @@ async def _store_and_record_image(
             obj.key,
             renditions=renditions_dict,
             include_thumbnail=include_thumbnail,
-            custom_width=custom_params.width,
-            custom_height=custom_params.height,
-            custom_fit=custom_params.fit,
-            custom_format=custom_params.format,
+            custom_params=custom_params,
             visibility=record.visibility,
             original_filename=img_data.original_filename,
+            placeholders=(record.dominant_color, record.blur_data_url),
         )
 
     except HTTPException:

--- a/app/routers/utils.py
+++ b/app/routers/utils.py
@@ -310,52 +310,36 @@ class CustomImageParams:
     format: str | None = None
 
 
-def _image_response(
-    record_id: str,
-    width: int | None,
-    height: int | None,
-    size_bytes: int | None,
-    storage_key: str,
-    renditions: dict[str, str] | None = None,
-    include_thumbnail: bool = False,
-    custom_params: CustomImageParams | None = None,
-    visibility: str = "public",
-    original_filename: str | None = None,
-    placeholders: tuple[str | None, str | None] | None = None,
-) -> dict:
-    """Shape the POST /upload/image response."""
+def _resolve_main_image_url(record_id: str, storage_key: str, visibility: str) -> str:
     if visibility == "public" and has_public_base_url():
-        main_url = public_object_url(storage_key)
-    else:
-        main_url = public_url(f"/files/{record_id}/download")
+        return public_object_url(storage_key)
+    return public_url(f"/files/{record_id}/download")
 
-    filtered_renditions = _filter_renditions(renditions, width)
 
-    response: dict[str, Any] = {
-        "status": "success",
-        "id": record_id,
-        "size_bytes": size_bytes,
-        "size_mb": round(size_bytes / (1024 * 1024), 2) if size_bytes else None,
-        "dimensions": {"width": width, "height": height},
-        "url": main_url,
-    }
-    if original_filename is not None:
-        response["original_filename"] = original_filename
+def _apply_placeholders(
+    response: dict[str, Any],
+    placeholders: tuple[str | None, str | None] | None,
+) -> None:
+    if not placeholders:
+        return
+    dominant_color, blur_data_url = placeholders
+    if dominant_color is not None:
+        response["dominant_color"] = dominant_color
+    if blur_data_url is not None:
+        response["blur_data_url"] = blur_data_url
 
-    if placeholders:
-        dominant_color, blur_data_url = placeholders
-        if dominant_color is not None:
-            response["dominant_color"] = dominant_color
-        if blur_data_url is not None:
-            response["blur_data_url"] = blur_data_url
 
-    if visibility != "public":
-        return response
-
+def _apply_public_image_fields(
+    response: dict[str, Any],
+    storage_key: str,
+    filtered_renditions: dict[str, str],
+    include_thumbnail: bool,
+    custom_params: CustomImageParams | None,
+) -> None:
     response["storage_key"] = storage_key
     response["renditions"] = filtered_renditions
 
-    if include_thumbnail or (filtered_renditions and "thumbnail" in filtered_renditions):
+    if include_thumbnail or "thumbnail" in filtered_renditions:
         response["thumbnail_url"] = derive_thumbnail_url(storage_key, filtered_renditions or None)
 
     if custom_params is not None:
@@ -368,5 +352,44 @@ def _image_response(
         )
         if custom_url is not None:
             response["custom_url"] = custom_url
+
+
+def _image_response(
+    record_id: str,
+    width: int | None,
+    height: int | None,
+    size_bytes: int | None,
+    storage_key: str,
+    renditions: dict[str, str] | None = None,
+    include_thumbnail: bool = False,
+    custom_params: CustomImageParams | None = None,
+    visibility: str = "public",
+    original_filename: str | None = None,
+    placeholders: tuple[str | None, str | None] | None = None,
+) -> dict[str, Any]:
+    """Shape the POST /upload/image response."""
+    filtered_renditions = _filter_renditions(renditions, width)
+
+    response: dict[str, Any] = {
+        "status": "success",
+        "id": record_id,
+        "size_bytes": size_bytes,
+        "size_mb": round(size_bytes / (1024 * 1024), 2) if size_bytes else None,
+        "dimensions": {"width": width, "height": height},
+        "url": _resolve_main_image_url(record_id, storage_key, visibility),
+    }
+    if original_filename is not None:
+        response["original_filename"] = original_filename
+
+    _apply_placeholders(response, placeholders)
+
+    if visibility == "public":
+        _apply_public_image_fields(
+            response,
+            storage_key=storage_key,
+            filtered_renditions=filtered_renditions,
+            include_thumbnail=include_thumbnail,
+            custom_params=custom_params,
+        )
 
     return response

--- a/app/routers/utils.py
+++ b/app/routers/utils.py
@@ -3,6 +3,7 @@ import hashlib
 import os
 import re
 import tempfile
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -301,6 +302,14 @@ def _derive_custom_transform_url(
     )
 
 
+@dataclass(frozen=True)
+class CustomImageParams:
+    width: int | None = None
+    height: int | None = None
+    fit: str = "auto"
+    format: str | None = None
+
+
 def _image_response(
     record_id: str,
     width: int | None,
@@ -309,12 +318,10 @@ def _image_response(
     storage_key: str,
     renditions: dict[str, str] | None = None,
     include_thumbnail: bool = False,
-    custom_width: int | None = None,
-    custom_height: int | None = None,
-    custom_fit: str = "auto",
-    custom_format: str | None = None,
+    custom_params: CustomImageParams | None = None,
     visibility: str = "public",
     original_filename: str | None = None,
+    placeholders: tuple[str | None, str | None] | None = None,
 ) -> dict:
     """Shape the POST /upload/image response."""
     if visibility == "public" and has_public_base_url():
@@ -335,6 +342,13 @@ def _image_response(
     if original_filename is not None:
         response["original_filename"] = original_filename
 
+    if placeholders:
+        dominant_color, blur_data_url = placeholders
+        if dominant_color is not None:
+            response["dominant_color"] = dominant_color
+        if blur_data_url is not None:
+            response["blur_data_url"] = blur_data_url
+
     if visibility != "public":
         return response
 
@@ -344,10 +358,15 @@ def _image_response(
     if include_thumbnail or (filtered_renditions and "thumbnail" in filtered_renditions):
         response["thumbnail_url"] = derive_thumbnail_url(storage_key, filtered_renditions or None)
 
-    custom_url = _derive_custom_transform_url(
-        storage_key, custom_width, custom_height, custom_fit, custom_format
-    )
-    if custom_url is not None:
-        response["custom_url"] = custom_url
+    if custom_params is not None:
+        custom_url = _derive_custom_transform_url(
+            storage_key,
+            custom_params.width,
+            custom_params.height,
+            custom_params.fit,
+            custom_params.format,
+        )
+        if custom_url is not None:
+            response["custom_url"] = custom_url
 
     return response

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -49,6 +49,12 @@ _CUSTOM_URL_DESC = (
     "width/height/fit/format; present only when custom transform parameters were "
     "supplied on a public upload"
 )
+_DOMINANT_COLOR_DESC = (
+    "Average dominant colour of the image formatted as a 7-character hex string (e.g. #1e293b)"
+)
+_BLUR_DATA_URL_DESC = (
+    "16px WebP encoded as a data:image/webp;base64,... URI for blurred image placeholder preview"
+)
 
 
 class ImageDimensions(BaseModel):
@@ -71,6 +77,8 @@ class _BaseImageUploadResponse(BaseModel):
     url: str | None = Field(default=None, description=_URL_DESC)
     thumbnail_url: str | None = Field(default=None, description=_THUMBNAIL_URL_DESC)
     custom_url: str | None = Field(default=None, description=_CUSTOM_URL_DESC)
+    dominant_color: str | None = Field(default=None, description=_DOMINANT_COLOR_DESC)
+    blur_data_url: str | None = Field(default=None, description=_BLUR_DATA_URL_DESC)
 
 
 class ImageUploadResponse(_BaseImageUploadResponse):
@@ -237,6 +245,8 @@ class FileRecord(BaseModel):
             "is configured, otherwise signed imgproxy URL. Public records only."
         ),
     )
+    dominant_color: str | None = Field(default=None, description=_DOMINANT_COLOR_DESC)
+    blur_data_url: str | None = Field(default=None, description=_BLUR_DATA_URL_DESC)
     created_at: str = Field(description="ISO-8601 timestamp")
     updated_at: str = Field(description="ISO-8601 timestamp")
 

--- a/app/services/image_vips.py
+++ b/app/services/image_vips.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import logging
 from dataclasses import dataclass
 
@@ -24,6 +25,8 @@ class ProcessedImage:
     width: int
     height: int
     renditions: dict[str, bytes]
+    dominant_color: str | None = None
+    blur_data_url: str | None = None
 
 
 # Allow-list of accepted input formats, checked via magic bytes before pyvips
@@ -62,6 +65,45 @@ def sniff_format(data: bytes) -> str | None:
         if major_brand in {b"avif", b"avis"}:
             return "avif"
     return None
+
+
+def _extract_placeholders(encoded: bytes) -> tuple[str, str]:
+    """Return (dominant_color_hex, blur_data_url) for an already-encoded image.
+
+    Deliberately derived from the *output* buffer rather than the full-resolution
+    source, for two reasons that only show up on real photos:
+
+    - pyvips recomputes a pipeline for every independent sink, so extracting from
+      the source forced a second full-resolution decode + ICC transform. Measured
+      on a 24.5MP iPhone photo: 591ms from the source vs 15.8ms here.
+    - Running before the MAX_IMAGE_PIXELS guard meant a decompression bomb was
+      fully decoded before being rejected (256ms vs 0.5ms for a 36MP input).
+
+    Reading back the output -- already normalized to sRGB, already downscaled --
+    avoids both, and is format-independent (shrink-on-load does not exist for
+    PNG, so shrinking the *source* is slow for exactly the formats a bomb uses).
+    At 16px on the long edge the lossy re-encode is immaterial.
+    """
+    tile = pyvips.Image.thumbnail_buffer(encoded, 16, height=16, size=pyvips.Size.DOWN)
+    if tile.hasalpha():
+        tile = tile.flatten(background=[255, 255, 255])
+
+    if tile.bands >= 3:
+        r = int(min(max(round(tile[0].avg()), 0), 255))
+        g = int(min(max(round(tile[1].avg()), 0), 255))
+        b = int(min(max(round(tile[2].avg()), 0), 255))
+    elif tile.bands == 1:
+        val = int(min(max(round(tile[0].avg()), 0), 255))
+        r = g = b = val
+    else:
+        r = g = b = 0
+    dominant_color = f"#{r:02x}{g:02x}{b:02x}"
+
+    tile_buf = tile.write_to_buffer(".webp", Q=20, strip=True, effort=0)
+    b64 = base64.b64encode(tile_buf).decode("ascii")
+    blur_data_url = f"data:image/webp;base64,{b64}"
+
+    return dominant_color, blur_data_url
 
 
 def _generate_materialized_renditions(image: pyvips.Image, width: int) -> dict[str, bytes]:
@@ -158,10 +200,19 @@ def validate_and_strip_image(
     optimized_buffer = image.write_to_buffer(
         ".webp", Q=q_value, strip=True, effort=effort, smart_subsample=True
     )
+
+    # Placeholders come from the encoded output, not the source -- see
+    # _extract_placeholders. This must stay after the encode; moving it earlier
+    # reintroduces both a second full-resolution decode and a bypass of the
+    # MAX_IMAGE_PIXELS guard above.
+    dominant_color, blur_data_url = _extract_placeholders(optimized_buffer)
+
     return ProcessedImage(
         buffer=optimized_buffer,
         content_type="image/webp",
         width=width,
         height=height,
         renditions=renditions,
+        dominant_color=dominant_color,
+        blur_data_url=blur_data_url,
     )

--- a/app/services/metadata/postgres.py
+++ b/app/services/metadata/postgres.py
@@ -30,7 +30,8 @@ _COLUMNS = (
     "id, owner, kind, storage_key, content_type, size_bytes, width, height, "
     "content_hash, status, task_id, original_filename, duration_seconds, truncated, "
     "callback_url, poster_upload_id, webhook_status, webhook_attempts, webhook_last_error, "
-    "webhook_updated_at, visibility, share_token, renditions, created_at, updated_at"
+    "webhook_updated_at, visibility, share_token, renditions, dominant_color, blur_data_url, "
+    "created_at, updated_at"
 )
 
 _JOIN_COLUMNS = (
@@ -38,7 +39,8 @@ _JOIN_COLUMNS = (
     "u.content_hash, u.status, u.task_id, u.original_filename, u.duration_seconds, u.truncated, "
     "u.callback_url, u.poster_upload_id, u.webhook_status, u.webhook_attempts, "
     "u.webhook_last_error, u.webhook_updated_at, u.visibility, u.share_token, "
-    "u.renditions, u.created_at, u.updated_at, p.storage_key AS poster_storage_key"
+    "u.renditions, u.dominant_color, u.blur_data_url, u.created_at, u.updated_at, "
+    "p.storage_key AS poster_storage_key"
 )
 
 
@@ -68,6 +70,8 @@ def _parse_renditions(raw: Any) -> dict[str, str] | None:
 def _row_to_record(row: asyncpg.Record) -> UploadRecord:
     poster_storage_key = row["poster_storage_key"] if "poster_storage_key" in row else None
     renditions = _parse_renditions(row["renditions"]) if "renditions" in row else None
+    dominant_color = row["dominant_color"] if "dominant_color" in row else None
+    blur_data_url = row["blur_data_url"] if "blur_data_url" in row else None
     return UploadRecord(
         id=row["id"],
         owner=row["owner"],
@@ -95,6 +99,8 @@ def _row_to_record(row: asyncpg.Record) -> UploadRecord:
         updated_at=row["updated_at"],
         poster_storage_key=poster_storage_key,
         renditions=renditions,
+        dominant_color=dominant_color,
+        blur_data_url=blur_data_url,
     )
 
 
@@ -192,13 +198,16 @@ class PostgresMetadataStore(MetadataStore):
     ) -> UploadRecord:
         callback_url = kwargs.get("callback_url")
         renditions = kwargs.get("renditions")
+        dominant_color = kwargs.get("dominant_color")
+        blur_data_url = kwargs.get("blur_data_url")
         upload_id = uuid.uuid4().hex
         renditions_json = json.dumps(renditions) if renditions is not None else None
         row = await self._fetchrow(
             f"INSERT INTO uploads (id, owner, kind, storage_key, content_type, size_bytes, "
             f"width, height, content_hash, status, task_id, original_filename, "
-            f"callback_url, visibility, renditions) "
-            f"VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15::jsonb) "
+            f"callback_url, visibility, renditions, dominant_color, blur_data_url) "
+            f"VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, "
+            f"$15::jsonb, $16, $17) "
             f"RETURNING {_COLUMNS}",
             upload_id,
             owner,
@@ -215,6 +224,8 @@ class PostgresMetadataStore(MetadataStore):
             callback_url,
             visibility,
             renditions_json,
+            dominant_color,
+            blur_data_url,
             error_msg=f"Failed to record upload {storage_key!r}",
         )
         assert row is not None  # INSERT ... RETURNING always yields a row

--- a/app/services/metadata/store.py
+++ b/app/services/metadata/store.py
@@ -44,7 +44,11 @@ class MetadataStore(ABC):
         original_filename: str | None = None,
         visibility: str = "private",
         **kwargs: object,
-    ) -> UploadRecord: ...
+    ) -> UploadRecord:
+        """Create a new upload record. Optional metadata fields such as
+        ``callback_url``, ``renditions``, ``dominant_color``, and ``blur_data_url``
+        are accepted via ``**kwargs`` to stay within parameter count limits."""
+        ...
 
     @abstractmethod
     async def set_task_id(self, upload_id: str, task_id: str) -> None:

--- a/app/services/metadata/types.py
+++ b/app/services/metadata/types.py
@@ -72,6 +72,8 @@ class UploadRecord:
     updated_at: datetime
     poster_storage_key: str | None = None
     renditions: dict[str, str] | None = None
+    dominant_color: str | None = None
+    blur_data_url: str | None = None
 
     def _populate_thumbnail_url(self, data: dict[str, Any]) -> None:
         """Static thumbnail URL for a public, ready image record."""
@@ -116,6 +118,17 @@ class UploadRecord:
 
         self._populate_thumbnail_url(data)
         self._populate_poster_url(data, poster_storage_key)
+
+    def _populate_placeholders(self, data: dict[str, Any]) -> None:
+        """Populate LQIP placeholder fields for ready image records.
+
+        Exposed regardless of visibility (deliberately breaks the
+        public-only symmetry of storage_key/renditions/accelerators
+        because placeholders leak no storage keys or URLs).
+        """
+        if self.kind == KIND_IMAGE and self.status == STATUS_READY:
+            data["dominant_color"] = self.dominant_color
+            data["blur_data_url"] = self.blur_data_url
 
     def _filtered_renditions(self) -> dict[str, str]:
         """Return renditions mapping, excluding width specs exceeding source width."""
@@ -163,5 +176,6 @@ class UploadRecord:
             if self.visibility == VISIBILITY_PUBLIC:
                 data["storage_key"] = self.storage_key
                 data["renditions"] = self._filtered_renditions()
+            self._populate_placeholders(data)
 
         return data

--- a/app/tasks.py
+++ b/app/tasks.py
@@ -364,6 +364,8 @@ async def _extract_and_store_poster(
                 width=processed.width,
                 height=processed.height,
                 visibility=visibility,
+                dominant_color=processed.dominant_color,
+                blur_data_url=processed.blur_data_url,
             )
         except MetadataError:
             # The object already exists in storage; a raised (not just a

--- a/docs/FILEMANAGER_INTEGRATION.md
+++ b/docs/FILEMANAGER_INTEGRATION.md
@@ -23,7 +23,7 @@ Integration guide for client applications and consuming backends using `filemana
 ## 2. Image Upload Contracts
 
 ### Single Upload (`POST /upload/image`)
-Supports `thumbnail=true` to generate responsive renditions and thumbnail:
+Supports `thumbnail=true` to generate responsive renditions and thumbnail. Every ready image response also carries LQIP placeholder fields (`dominant_color` and `blur_data_url`):
 
 ```json
 {
@@ -39,6 +39,8 @@ Supports `thumbnail=true` to generate responsive renditions and thumbnail:
   "dimensions": { "width": 1920, "height": 1280 },
   "size_bytes": 145020,
   "size_mb": 0.14,
+  "dominant_color": "#1e293b",
+  "blur_data_url": "data:image/webp;base64,UklGRl...",
   "url": "https://cdn.example.com/images/4b17c80521ad47a884819ca1e7c9bf8f.webp",
   "thumbnail_url": "https://cdn.example.com/images/4b17c80521ad47a884819ca1e7c9bf8f_t300.webp"
 }
@@ -59,6 +61,8 @@ Guarantees 1:1 positional array mapping with explicit status discriminator and c
       "storage_key": "images/abc.webp",
       "renditions": { "thumbnail": "images/abc_t300.webp", "w400": "images/abc_w400.webp" },
       "dimensions": { "width": 600, "height": 400 },
+      "dominant_color": "#1e293b",
+      "blur_data_url": "data:image/webp;base64,UklGRl...",
       "url": "https://cdn.example.com/images/abc.webp",
       "thumbnail_url": "https://cdn.example.com/images/abc_t300.webp"
     }
@@ -103,6 +107,15 @@ When a public upload completes, store:
 2. `storage_key` — the relative object path for the primary asset (e.g. `images/4b17c80521ad47a884819ca1e7c9bf8f.webp`).
 3. `renditions` — a JSON map of rendition names to their relative storage keys (e.g. `{"thumbnail": "images/..._t300.webp", "w400": "images/..._w400.webp"}`).
 4. `width` & `height` — dimensions for layout calculation and aspect-ratio preservation.
+5. `dominant_color` & `blur_data_url` — LQIP placeholders for instant rendering while loading.
+
+### Using LQIP Placeholders on the Consumer
+Every ready image record carries:
+- `dominant_color` (e.g. `#1e293b`): Use as `background-color` on the image wrapper for a solid background before any bytes load.
+- `blur_data_url` (16px WebP base64 URI): Use as an inline blur preview (e.g. Next.js `<Image placeholder="blur" blurDataURL={photo.blur_data_url} />` or an underlying `<img>` with CSS `filter: blur(20px)`). The service intentionally does **not** pre-blur the 16px tile to minimize payload size and preserve consumer control over blur radius.
+
+> [!NOTE]
+> Unlike accelerator URLs (`thumbnail_url`, `poster_url`) and `storage_key`, `dominant_color` and `blur_data_url` are exposed on **both public and private records** (gated on `kind == "image"` and `status == "ready"`), since they leak no storage keys or object URLs.
 
 ### Constructing URLs on the Consumer
 Consumers configure `MEDIA_BASE_URL` (e.g. `https://cdn.example.com`) and build URLs via simple string concatenation:

--- a/docs/plans/media-engine/session-2-placeholders.md
+++ b/docs/plans/media-engine/session-2-placeholders.md
@@ -74,11 +74,21 @@ def _extract_placeholders(image: pyvips.Image) -> tuple[str, str]:
   rounded, formatted `f"#{r:02x}{g:02x}{b:02x}"`. Session 1's `colourspace`
   normalization guarantees ≥3 bands, so a greyscale input is already expanded;
   add a defensive guard anyway if band count < 3.
-- **Blur tile:** `image.thumbnail_image(16, height=16, size=pyvips.Size.DOWN,
-  crop=pyvips.Interesting.NONE)` → `write_to_buffer(".webp", Q=20, strip=True,
+- **Blur tile:** `pyvips.Image.thumbnail_buffer(<encoded output>, 16, height=16,
+  size=pyvips.Size.DOWN)` → `write_to_buffer(".webp", Q=20, strip=True,
   effort=0)` → `base64.b64encode` → `f"data:image/webp;base64,{b64}"`.
   `effort=0` deliberately: at 16px the file-size difference between effort 0
   and 6 is a handful of bytes and the point is that this is nearly free.
+
+> **Corrected after implementation.** This item originally said to extract from
+> the normalized pyvips image *before* the max-dim resize. That was wrong on both
+> counts and the measurements are in `CLAUDE.md`: extract from the **encoded
+> output buffer**, after `write_to_buffer` and therefore after the
+> `MAX_IMAGE_PIXELS` guard. Extracting from the source forces a second
+> full-resolution decode (591ms on a 24.5MP photo vs 15.8ms), and sitting above
+> the pixel guard lets a decompression bomb decode fully before rejection
+> (256ms vs 0.3ms). Beware of measuring this on a `.copy_memory()`-materialized
+> image -- that hides the decode and reports ~1.6ms for a 591ms operation.
 
 Add both to the `ProcessedImage` dataclass:
 

--- a/migrations/versions/0008_uploads_blur_and_color.py
+++ b/migrations/versions/0008_uploads_blur_and_color.py
@@ -1,0 +1,34 @@
+"""add dominant_color and blur_data_url columns to uploads
+
+LQIP placeholders for ready images:
+- dominant_color: average colour as 7-char hex string, e.g. '#1e293b'
+- blur_data_url: 16px WebP encoded as 'data:image/webp;base64,...' URI
+
+Both columns are nullable, unindexed, with no default and no backfill.
+Existing rows retain NULL for both fields.
+
+Revision ID: 0008_uploads_blur_and_color
+Revises: 0007_uploads_renditions
+Create Date: 2026-08-24
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0008_uploads_blur_and_color"
+down_revision: str | None = "0007_uploads_renditions"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE uploads ADD COLUMN dominant_color varchar(7)")
+    op.execute("ALTER TABLE uploads ADD COLUMN blur_data_url text")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE uploads DROP COLUMN IF EXISTS dominant_color")
+    op.execute("ALTER TABLE uploads DROP COLUMN IF EXISTS blur_data_url")

--- a/readme.md
+++ b/readme.md
@@ -488,6 +488,8 @@ Retrieve record details via `GET /files/{id}`:
   "webhook_last_error": null,
   "webhook_updated_at": null,
   "visibility": "public",
+  "dominant_color": "#1e293b",
+  "blur_data_url": "data:image/webp;base64,UklGRl...",
   "url": "https://cdn.example.com/images/0f1c2b7a5e4d4a9c8f2b1d6e3a7c0b95.webp",
   "thumbnail_url": "https://cdn.example.com/images/0f1c2b7a5e4d4a9c8f2b1d6e3a7c0b95_t300.webp",
   "created_at": "2026-08-15T09:11:02+00:00",
@@ -496,6 +498,7 @@ Retrieve record details via `GET /files/{id}`:
 ```
 
 - **`storage_key` & `renditions`:** Raw relative object keys, allowing consumers to construct URLs as `{MEDIA_BASE_URL}/{key}` without API calls on page renders (resolve-once).
+- **`dominant_color` & `blur_data_url`:** Lightweight LQIP placeholders exposed on all ready images regardless of visibility.
 - **`url`:** Direct CDN URL when a public base URL is configured, or canonical `/files/{id}/download` on local storage or private records.
 - **`thumbnail_url` / `poster_url`:** Public-only accelerators (withheld on private records).
 - **`GET /files`:** Returns paginated records: `{"files": [...], "total_count": N, "limit": L, "offset": O}`.

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -165,6 +165,8 @@ class InMemoryMetadataStore(MetadataStore):
     ) -> UploadRecord:
         callback_url = kwargs.get("callback_url")
         renditions = kwargs.get("renditions")
+        dominant_color = kwargs.get("dominant_color")
+        blur_data_url = kwargs.get("blur_data_url")
         self._counter += 1
         upload_id = f"rec-{self._counter:08d}"
         now = datetime.now(UTC)
@@ -194,6 +196,8 @@ class InMemoryMetadataStore(MetadataStore):
             created_at=now,
             updated_at=now,
             renditions=renditions,
+            dominant_color=dominant_color,
+            blur_data_url=blur_data_url,
         )
         self.records[upload_id] = record
         self._order.append(upload_id)

--- a/tests/test_files_batch.py
+++ b/tests/test_files_batch.py
@@ -120,3 +120,27 @@ async def test_batch_partial_miss_logs_warning(
         f"Batch lookup partial miss: owner={OWNER} requested=3 returned=1" in rec.message
         for rec in warning_logs
     )
+
+
+async def test_batch_includes_placeholders(
+    client: httpx.AsyncClient,
+    auth_headers: dict[str, str],
+    fake_metadata: InMemoryMetadataStore,
+) -> None:
+    rec = await fake_metadata.create(
+        owner=OWNER,
+        kind=KIND_IMAGE,
+        storage_key="images/ph.webp",
+        content_type="image/webp",
+        size_bytes=10,
+        status=STATUS_READY,
+        visibility="public",
+        dominant_color="#1e293b",
+        blur_data_url="data:image/webp;base64,UklGRl...",
+    )
+    resp = await client.post("/files/batch", headers=auth_headers, json={"ids": [rec.id]})
+    assert resp.status_code == 200
+    files = resp.json()["files"]
+    assert len(files) == 1
+    assert files[0]["dominant_color"] == "#1e293b"
+    assert files[0]["blur_data_url"] == "data:image/webp;base64,UklGRl..."

--- a/tests/test_files_listing.py
+++ b/tests/test_files_listing.py
@@ -137,3 +137,36 @@ async def test_get_requires_auth(
 ) -> None:
     record = await _seed(fake_metadata, OWNER, "image", "images/a.webp")
     assert (await client.get(f"/files/{record.id}")).status_code == 401
+
+
+async def test_list_and_get_include_placeholders(
+    client: httpx.AsyncClient,
+    auth_headers: dict[str, str],
+    fake_metadata: InMemoryMetadataStore,
+) -> None:
+    rec = await fake_metadata.create(
+        owner=OWNER,
+        kind="image",
+        storage_key="images/ph.webp",
+        content_type="image/webp",
+        size_bytes=10,
+        status="ready",
+        visibility="public",
+        dominant_color="#1e293b",
+        blur_data_url="data:image/webp;base64,UklGRl...",
+    )
+    # Test GET /files/{id}
+    resp = await client.get(f"/files/{rec.id}", headers=auth_headers)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["dominant_color"] == "#1e293b"
+    assert body["blur_data_url"] == "data:image/webp;base64,UklGRl..."
+
+    # Test GET /files
+    list_resp = await client.get("/files", headers=auth_headers)
+    assert list_resp.status_code == 200
+    files = list_resp.json()["files"]
+    target = next((f for f in files if f["id"] == rec.id), None)
+    assert target is not None
+    assert target["dominant_color"] == "#1e293b"
+    assert target["blur_data_url"] == "data:image/webp;base64,UklGRl..."

--- a/tests/test_image_vips.py
+++ b/tests/test_image_vips.py
@@ -1,10 +1,16 @@
+import base64
+import re
+import time
+
 import pytest
 import pyvips
 
 from app.config import settings
+from app.services import image_vips
 from app.services.image_vips import (
     ImageValidationError,
     ProcessedImage,
+    _extract_placeholders,
     sniff_format,
     validate_and_strip_image,
 )
@@ -174,3 +180,106 @@ def test_corrupt_icc_profile_does_not_fail_upload(monkeypatch: pytest.MonkeyPatc
     assert result.content_type == "image/webp"
     assert result.width == 40
     assert result.height == 40
+
+
+def test_placeholders_extracted_and_bounded() -> None:
+    """Every ready image extracts dominant_color and blur_data_url within budget bounds."""
+    raw = fixture_bytes("tiny.png")
+    result = validate_and_strip_image(raw)
+
+    # 1. Dominant colour matches 7-char hex string #rrggbb
+    assert result.dominant_color is not None
+    assert re.match(r"^#[0-9a-f]{6}$", result.dominant_color)
+
+    # 2. blur_data_url starts with data URI scheme
+    assert result.blur_data_url is not None
+    assert result.blur_data_url.startswith("data:image/webp;base64,")
+
+    # 3. Decoded payload is a valid WebP image with long edge <= 16px
+    b64_payload = result.blur_data_url.removeprefix("data:image/webp;base64,")
+    decoded_bytes = base64.b64decode(b64_payload)
+    assert decoded_bytes[:4] == b"RIFF"
+    assert decoded_bytes[8:12] == b"WEBP"
+
+    tile_image = pyvips.Image.new_from_buffer(decoded_bytes, "")
+    assert tile_image.width <= 16
+    assert tile_image.height <= 16
+
+    # 4. Payload budget tripwire: <= 1200 bytes
+    assert len(result.blur_data_url) <= 1200
+
+
+def test_dominant_color_accuracy_on_known_solid_color() -> None:
+    """A known solid RGB colour produces approximately that hex colour."""
+    # Synthesize a solid colour image: RGB (180, 50, 100) => #b43264
+    img = pyvips.Image.black(32, 32, bands=3).copy(interpretation="srgb") + [180, 50, 100]
+    png_bytes = img.write_to_buffer(".png")
+
+    result = validate_and_strip_image(png_bytes)
+    assert result.dominant_color is not None
+
+    r = int(result.dominant_color[1:3], 16)
+    g = int(result.dominant_color[3:5], 16)
+    b = int(result.dominant_color[5:7], 16)
+
+    # Separate atomic assertions per channel with tight tolerance
+    assert abs(r - 180) <= 2
+    assert abs(g - 50) <= 2
+    assert abs(b - 100) <= 2
+
+
+def test_placeholder_alpha_flattening() -> None:
+    """Transparent PNG is flattened on white before computing dominant colour and blur tile."""
+    # Transparent image: RGB (0, 0, 0) with alpha 0 => flattened on white (255, 255, 255) => #ffffff
+    transparent_img = pyvips.Image.black(32, 32, bands=4)
+    png_bytes = transparent_img.write_to_buffer(".png")
+
+    result = validate_and_strip_image(png_bytes)
+    assert result.dominant_color == "#ffffff"
+    assert result.blur_data_url is not None
+    assert result.blur_data_url.startswith("data:image/webp;base64,")
+
+
+def test_placeholder_extraction_performance() -> None:
+    """Extraction from the encoded output stays well inside the 15ms budget.
+
+    Measured from real encoded bytes on purpose. An earlier version of this test
+    called `.copy_memory()` on a pyvips image first, which pre-materialized the
+    pixels and hid the decode that dominates the real cost -- it reported 1.6ms
+    while a genuine 24.5MP photo took 591ms.
+    """
+    img = pyvips.Image.black(1920, 1280, bands=3).copy(interpretation="srgb") + [120, 140, 160]
+    encoded = img.write_to_buffer(".webp", Q=85, strip=True, effort=4)
+
+    _extract_placeholders(encoded)  # warm up libvips
+
+    t0 = time.perf_counter()
+    iterations = 10
+    for _ in range(iterations):
+        _extract_placeholders(encoded)
+    duration_per_call_ms = ((time.perf_counter() - t0) / iterations) * 1000
+
+    assert duration_per_call_ms < 15.0
+
+
+def test_oversized_image_rejected_before_any_placeholder_work(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The MAX_IMAGE_PIXELS guard must fire before any pixel work happens.
+
+    pyvips is lazy, so whichever call forces evaluation first pays for a full
+    decode. When placeholder extraction sat above this guard, a 36MP
+    decompression bomb was fully decoded before being rejected -- 256ms versus
+    0.5ms. Asserting on call ordering rather than elapsed time keeps this
+    deterministic on a loaded CI box.
+    """
+
+    def _fail(*args: object, **kwargs: object) -> tuple[str, str]:
+        raise AssertionError("placeholder extraction ran before the pixel-count guard")
+
+    monkeypatch.setattr(settings, "MAX_IMAGE_PIXELS", 10)  # tiny.png is 8x8 = 64 pixels
+    monkeypatch.setattr(image_vips, "_extract_placeholders", _fail)
+    raw = fixture_bytes("tiny.png")
+
+    with pytest.raises(ImageValidationError, match="exceed"):
+        validate_and_strip_image(raw)

--- a/tests/test_metadata_store.py
+++ b/tests/test_metadata_store.py
@@ -165,3 +165,43 @@ async def test_mark_failed_transitions_status() -> None:
     updated = await store.mark_failed(rec.id)
     assert updated is not None
     assert updated.status == STATUS_FAILED
+
+
+async def test_placeholders_persistence_roundtrip() -> None:
+    store = InMemoryMetadataStore()
+    rec = await store.create(
+        owner="alice",
+        kind=KIND_IMAGE,
+        storage_key="images/ph.webp",
+        content_type="image/webp",
+        size_bytes=100,
+        status=STATUS_READY,
+        dominant_color="#1e293b",
+        blur_data_url="data:image/webp;base64,UklGRl...",
+    )
+    assert rec.dominant_color == "#1e293b"
+    assert rec.blur_data_url == "data:image/webp;base64,UklGRl..."
+
+    fetched = await store.get(rec.id, "alice")
+    assert fetched is not None
+    assert fetched.dominant_color == "#1e293b"
+    assert fetched.blur_data_url == "data:image/webp;base64,UklGRl..."
+
+
+async def test_placeholders_null_for_unprovided() -> None:
+    store = InMemoryMetadataStore()
+    rec = await store.create(
+        owner="alice",
+        kind=KIND_IMAGE,
+        storage_key="images/noph.webp",
+        content_type="image/webp",
+        size_bytes=100,
+        status=STATUS_READY,
+    )
+    assert rec.dominant_color is None
+    assert rec.blur_data_url is None
+
+    fetched = await store.get(rec.id, "alice")
+    assert fetched is not None
+    assert fetched.dominant_color is None
+    assert fetched.blur_data_url is None

--- a/tests/test_metadata_store_pg.py
+++ b/tests/test_metadata_store_pg.py
@@ -460,3 +460,52 @@ async def test_renditions_jsonb_roundtrip(pg_store: PostgresMetadataStore) -> No
     refetched = await pg_store.get(rec.id, "alice")
     assert refetched is not None
     assert refetched.renditions == {"thumbnail": "images/rot_t300.webp"}
+
+
+async def test_placeholders_persistence_roundtrip(pg_store: PostgresMetadataStore) -> None:
+    rec = await pg_store.create(
+        owner="alice",
+        kind=KIND_IMAGE,
+        storage_key="images/ph.webp",
+        content_type="image/webp",
+        size_bytes=100,
+        status=STATUS_READY,
+        dominant_color="#1e293b",
+        blur_data_url="data:image/webp;base64,UklGRl...",
+    )
+    assert rec.dominant_color == "#1e293b"
+    assert rec.blur_data_url == "data:image/webp;base64,UklGRl..."
+
+    fetched = await pg_store.get(rec.id, "alice")
+    assert fetched is not None
+    assert fetched.dominant_color == "#1e293b"
+    assert fetched.blur_data_url == "data:image/webp;base64,UklGRl..."
+
+    # Also verified on get_many and list
+    many = await pg_store.get_many("alice", [rec.id])
+    assert len(many) == 1
+    assert many[0].dominant_color == "#1e293b"
+    assert many[0].blur_data_url == "data:image/webp;base64,UklGRl..."
+
+    listed = await pg_store.list("alice")
+    assert len(listed) == 1
+    assert listed[0].dominant_color == "#1e293b"
+    assert listed[0].blur_data_url == "data:image/webp;base64,UklGRl..."
+
+
+async def test_placeholders_null_for_unprovided(pg_store: PostgresMetadataStore) -> None:
+    rec = await pg_store.create(
+        owner="alice",
+        kind=KIND_IMAGE,
+        storage_key="images/noph.webp",
+        content_type="image/webp",
+        size_bytes=100,
+        status=STATUS_READY,
+    )
+    assert rec.dominant_color is None
+    assert rec.blur_data_url is None
+
+    fetched = await pg_store.get(rec.id, "alice")
+    assert fetched is not None
+    assert fetched.dominant_color is None
+    assert fetched.blur_data_url is None

--- a/tests/test_poster.py
+++ b/tests/test_poster.py
@@ -67,6 +67,10 @@ async def test_generate_poster_creates_linked_webp_image_record(
     assert not poster.renditions
     assert not any("posters/" in k and "_t300" in k for k in fake_storage.objects)
     assert not any("posters/" in k and "_m960" in k for k in fake_storage.objects)
+    assert poster.dominant_color is not None
+    assert poster.dominant_color.startswith("#")
+    assert poster.blur_data_url is not None
+    assert poster.blur_data_url.startswith("data:image/webp;base64,")
 
     # The video row now points at its poster.
     video = await fake_metadata.get(video_id, OWNER)

--- a/tests/test_routes_image_upload.py
+++ b/tests/test_routes_image_upload.py
@@ -144,3 +144,65 @@ async def test_corrupt_bytes_upload_is_rejected(
         files={"file": ("fake.png", fixture_bytes("corrupt.bin"), "image/png")},
     )
     assert resp.status_code == 400
+
+
+async def test_image_upload_carries_placeholders(
+    client: httpx.AsyncClient, auth_headers: dict[str, str]
+) -> None:
+    resp = await client.post(
+        "/upload/image",
+        headers=auth_headers,
+        files={"file": ("tiny.png", fixture_bytes("tiny.png"), "image/png")},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "dominant_color" in body
+    assert body["dominant_color"].startswith("#")
+    assert "blur_data_url" in body
+    assert body["blur_data_url"].startswith("data:image/webp;base64,")
+
+
+async def test_private_image_upload_carries_placeholders(
+    client: httpx.AsyncClient, auth_headers: dict[str, str]
+) -> None:
+    """Private uploads withhold storage_key/renditions/accelerators but expose placeholders."""
+    resp = await client.post(
+        "/upload/image",
+        headers=auth_headers,
+        data={"visibility": "private"},
+        files={"file": ("tiny.png", fixture_bytes("tiny.png"), "image/png")},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "storage_key" not in body
+    assert "renditions" not in body
+    assert "thumbnail_url" not in body
+    assert "dominant_color" in body
+    assert body["dominant_color"].startswith("#")
+    assert "blur_data_url" in body
+    assert body["blur_data_url"].startswith("data:image/webp;base64,")
+
+
+async def test_dedup_image_upload_carries_placeholders(
+    client: httpx.AsyncClient, auth_headers: dict[str, str]
+) -> None:
+    """A deduplicated image upload echoes placeholders from the existing record."""
+    resp1 = await client.post(
+        "/upload/image",
+        headers=auth_headers,
+        files={"file": ("tiny.png", fixture_bytes("tiny.png"), "image/png")},
+    )
+    assert resp1.status_code == 200
+    body1 = resp1.json()
+
+    resp2 = await client.post(
+        "/upload/image",
+        headers=auth_headers,
+        files={"file": ("tiny.png", fixture_bytes("tiny.png"), "image/png")},
+    )
+    assert resp2.status_code == 200
+    body2 = resp2.json()
+
+    assert body2["id"] == body1["id"]
+    assert body2["dominant_color"] == body1["dominant_color"]
+    assert body2["blur_data_url"] == body1["blur_data_url"]

--- a/tests/test_upload_records.py
+++ b/tests/test_upload_records.py
@@ -37,6 +37,10 @@ async def test_image_upload_creates_a_ready_record(
     assert record.status == "ready"
     assert record.storage_key.startswith("images/")
     assert record.content_type == "image/webp"
+    assert record.dominant_color is not None
+    assert record.blur_data_url is not None
+    assert body["dominant_color"] == record.dominant_color
+    assert body["blur_data_url"] == record.blur_data_url
 
 
 async def test_video_upload_creates_a_processing_record_with_task_id(


### PR DESCRIPTION
Every ready image record now carries two tiny, self-contained placeholder values so a consumer can paint something meaningful before the real bytes arrive:

- **`dominant_color`** — average colour as `#rrggbb`, for a solid background behind a loading image.
- **`blur_data_url`** — a 16px WebP as a `data:image/webp;base64,...` URI (135–167 bytes in practice), for a blurred preview (Next.js `placeholder="blur"` and equivalents).

Migration `0008` adds both columns, nullable, no backfill. `alembic downgrade -1` rolls back and re-applies cleanly — verified against the real Postgres service.

## Exposed regardless of visibility

This deliberately breaks the "extras are public-only" symmetry of `storage_key` / `renditions` / accelerator URLs. These two fields carry no storage key, no URL and nothing cross-tenant, and a private record needs a placeholder exactly as much as a public one. A test asserts placeholders are present on a private upload *while* `storage_key`, `renditions` and `thumbnail_url` are absent.

## `IMAGE_PIPELINE_VERSION` is deliberately NOT bumped

This adds metadata; it does not change the bytes of any stored object. Bumping would force a pointless re-encode of every re-uploaded image. Pre-existing rows carry `NULL`. Flagging it here because a reviewer would reasonably expect the opposite.

## Where the tile comes from, and why it matters

The placeholder is derived from the **encoded output buffer**, after the main `write_to_buffer`. That placement is load-bearing twice over — both found by measuring on a real 24.5MP iPhone photo rather than a fixture:

- **pyvips recomputes a pipeline for every independent sink.** Extracting from the full-resolution source forced a *second* full decode + ICC transform: **591ms from the source vs 15.8ms** reading the output back. `thumbnail_buffer` on the *source* is not the fix either — shrink-on-load does not exist for PNG, where it measured 62.7ms, slower than on HEIC.
- **It must sit below the `MAX_IMAGE_PIXELS` guard.** Extraction is the first call that forces evaluation, so above the guard a decompression bomb decodes fully before being rejected: a 120KB, 36-megapixel PNG took **256ms to reject instead of 0.3ms**, synchronously, on an endpoint rate-limited at only 2 r/s per IP.

`test_oversized_image_rejected_before_any_placeholder_work` pins that ordering by monkeypatching the extractor to raise, so it fails deterministically rather than on a timing threshold.

The performance test was also rewritten: the original called `.copy_memory()` first, which pre-materialized the pixels and hid the decode — it reported 1.6ms for what is a 591ms operation on a real photo.

## The trade-off, measured

Deriving from the lossy, downscaled output rather than the original source could in principle shift the placeholder. Measured across three real photos and all three optimization profiles:

| Photo | vs source | across profiles |
|---|---|---|
| IMG_6034.HEIC (4284×5712) | ≤1 / 255 per channel | 1 |
| IMG_6342.HEIC (3024×4032) | 0 | 0 |
| prof-pic.jpg (1024×1024) | 0 | 0 |

At most one unit out of 255. Blur payload sizes are identical across profiles.

## Verification

`487 passed, 14 skipped` · `ruff check` · `ruff format --check` · `mypy app` — all clean via `docker compose run --rm --build test`.

End to end through the running stack on real iPhone photos:

| Photo | Total | Notes |
|---|---|---|
| 4284×5712 HEIC | 763 ms | vs a 745 ms pre-placeholder baseline → ~18 ms of placeholder cost |
| 3024×4032 HEIC | 502 ms | |
| 1024×1024 JPEG | 110 ms | |
| 36MP PNG bomb | 0.3 ms | rejected before any decode |

Blur payloads 135–167 bytes against a 1200-byte tripwire test.

## Notes for the reviewer

- The `INSERT` in `PostgresMetadataStore.create` went from 15 to 17 placeholders — column list, `$N` list and positional args all verified to line up.
- `_image_response` was **11 parameters** after refactoring `custom_*` into the shared `CustomImageParams` dataclass, down from 12 and under the ≤13 bound.
- `docs/plans/media-engine/session-2-placeholders.md` carries a "Corrected after implementation" note: the plan's original guidance (extract from the normalized source, before the max-dim resize) was wrong on both counts, and the note records the measurements so the mistake isn't repeated.
