### PR TITLE
feat(images): smart attention crop for thumbnails + lossless profile

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -173,6 +173,19 @@ class Settings(BaseSettings):
     # Decompression-bomb guard: reject images decoding to more than this
     # many total pixels (width * height), before the full-resolution encode.
     MAX_IMAGE_PIXELS: int = Field(default=50_000_000)
+    # `optimization=lossless` guards. Lossless cost tracks content entropy, NOT
+    # pixel count -- measured, a 14.7MP flat-colour screenshot encodes in 262ms
+    # to 5KB while a 12.2MP photograph takes 5563ms and produces 6.1MB. A pixel
+    # cap would therefore block the intended use and permit the abusive one, so
+    # the guard is a cheap entropy probe instead: lossless-encode a 512px
+    # thumbnail and measure bytes-per-pixel. Screenshots land at 0.012-0.018,
+    # photographs at 0.66-1.27, so anything in 0.05-0.3 separates them with a
+    # wide margin. The probe costs ~32ms and avoids a ~5.5s encode.
+    LOSSLESS_MAX_PROBE_BYTES_PER_PIXEL: float = Field(default=0.25)
+    # Backstop for content the probe misjudges: reject a lossless result whose
+    # encoded size exceeds this. Bounds stored-object size even when the CPU
+    # has already been spent.
+    LOSSLESS_MAX_OUTPUT_BYTES: int = Field(default=8 * 1024 * 1024)
     # QR codes have a hard capacity limit (~2953 bytes at version 40/level L);
     # this just rejects absurd input before it ever reaches segno.
     MAX_QR_CONTENT_LENGTH: int = Field(default=2000)

--- a/app/config.py
+++ b/app/config.py
@@ -173,18 +173,14 @@ class Settings(BaseSettings):
     # Decompression-bomb guard: reject images decoding to more than this
     # many total pixels (width * height), before the full-resolution encode.
     MAX_IMAGE_PIXELS: int = Field(default=50_000_000)
-    # `optimization=lossless` guards. Lossless cost tracks content entropy, NOT
-    # pixel count -- measured, a 14.7MP flat-colour screenshot encodes in 262ms
-    # to 5KB while a 12.2MP photograph takes 5563ms and produces 6.1MB. A pixel
-    # cap would therefore block the intended use and permit the abusive one, so
-    # the guard is a cheap entropy probe instead: lossless-encode a 512px
-    # thumbnail and measure bytes-per-pixel. Screenshots land at 0.012-0.018,
-    # photographs at 0.66-1.27, so anything in 0.05-0.3 separates them with a
-    # wide margin. The probe costs ~32ms and avoids a ~5.5s encode.
-    LOSSLESS_MAX_PROBE_BYTES_PER_PIXEL: float = Field(default=0.25)
-    # Backstop for content the probe misjudges: reject a lossless result whose
-    # encoded size exceeds this. Bounds stored-object size even when the CPU
-    # has already been spent.
+    # `optimization=lossless` cost guard. Lossless cost tracks content entropy,
+    # NOT pixel count -- measured, a 14.7MP flat-colour screenshot encodes in
+    # 262ms to 5KB while a 12.2MP photograph takes 5563ms and produces 6.1MB.
+    # A 512px lossless probe yields a bytes-per-pixel figure that is essentially
+    # constant for a given image regardless of its size (1.265-1.297 measured
+    # across 0.25MP-12MP crops of the same photo), so `bpp * pixels` projects
+    # the real output size and is checked against this limit before the
+    # expensive encode runs. The same limit is re-checked on the actual result.
     LOSSLESS_MAX_OUTPUT_BYTES: int = Field(default=8 * 1024 * 1024)
     # QR codes have a hard capacity limit (~2953 bytes at version 40/level L);
     # this just rejects absurd input before it ever reaches segno.

--- a/app/routers/upload.py
+++ b/app/routers/upload.py
@@ -439,8 +439,11 @@ async def upload_image(
     format: Literal["webp", "png", "jpg", "jpeg", "avif", "gif"] | None = Form(
         default=None, json_schema_extra={"example": None}
     ),
-    optimization: Literal["size", "balanced", "quality"] = Form(
-        "balanced", description="Encoding profile for initial image compression"
+    optimization: Literal["size", "balanced", "quality", "lossless"] = Form(
+        "balanced",
+        description=(
+            "Encoding profile for initial image compression (lossless caps dimensions at 4096px)"
+        ),
     ),
     visibility: Literal["public", "private"] = Form("public"),
     owner: str = Depends(require_image_upload),
@@ -502,8 +505,12 @@ _BULK_UPLOAD_OPENAPI_EXTRA = {
                         },
                         "optimization": {
                             "type": "string",
-                            "enum": ["size", "balanced", "quality"],
+                            "enum": ["size", "balanced", "quality", "lossless"],
                             "default": "balanced",
+                            "description": (
+                                "Encoding profile for initial image compression "
+                                "(lossless caps dimensions at 4096px)"
+                            ),
                         },
                         "visibility": {
                             "type": "string",
@@ -598,8 +605,11 @@ async def upload_images(
     format: Literal["webp", "png", "jpg", "jpeg", "avif", "gif"] | None = Form(
         default=None, json_schema_extra={"example": None}
     ),
-    optimization: Literal["size", "balanced", "quality"] = Form(
-        "balanced", description="Encoding profile for initial image compression"
+    optimization: Literal["size", "balanced", "quality", "lossless"] = Form(
+        "balanced",
+        description=(
+            "Encoding profile for initial image compression (lossless caps dimensions at 4096px)"
+        ),
     ),
     visibility: Literal["public", "private"] = Form("public"),
     owner: str = Depends(require_image_upload),

--- a/app/routers/upload.py
+++ b/app/routers/upload.py
@@ -83,8 +83,9 @@ DETAIL_STORAGE_UNAVAILABLE = "Storage backend unavailable"
 # Static and deliberately specific: this names the caller's own parameter,
 # leaks nothing internal, and a generic 400 would leave them no way to act.
 DETAIL_LOSSLESS_UNSUITABLE = (
-    "optimization=lossless is for flat-colour graphics (diagrams, screenshots, "
-    "logos); this image is photographic -- use optimization=quality"
+    "optimization=lossless would produce an oversized object for this image; "
+    "it is intended for flat-colour graphics (diagrams, screenshots, logos) -- "
+    "use optimization=quality"
 )
 DETAIL_UPLOAD_FAILED = "Upload could not be completed"
 

--- a/app/routers/upload.py
+++ b/app/routers/upload.py
@@ -51,6 +51,7 @@ from app.services.file_validation import (
 from app.services.image_vips import (
     IMAGE_PIPELINE_VERSION,
     ImageValidationError,
+    LosslessUnsuitableError,
     validate_and_strip_image,
 )
 from app.services.metadata import (
@@ -79,6 +80,12 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 DETAIL_STORAGE_UNAVAILABLE = "Storage backend unavailable"
+# Static and deliberately specific: this names the caller's own parameter,
+# leaks nothing internal, and a generic 400 would leave them no way to act.
+DETAIL_LOSSLESS_UNSUITABLE = (
+    "optimization=lossless is for flat-colour graphics (diagrams, screenshots, "
+    "logos); this image is photographic -- use optimization=quality"
+)
 DETAIL_UPLOAD_FAILED = "Upload could not be completed"
 
 
@@ -216,16 +223,16 @@ async def _process_single_image(
             )
         except ImageValidationError as exc:
             logger.warning("Image validation rejected upload: %s", exc)
+            unsuitable = isinstance(exc, LosslessUnsuitableError)
+            detail = DETAIL_LOSSLESS_UNSUITABLE if unsuitable else "Invalid or unsupported image"
             if not raise_on_error:
                 return {
                     "status": "error",
                     "code": "invalid_image",
-                    "message": "Invalid or unsupported image",
+                    "message": detail,
                     "original_filename": original_filename,
                 }
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid or unsupported image"
-            ) from exc
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=detail) from exc
 
         unique_id = uuid.uuid4().hex
         prefix = storage_prefix("images", visibility)
@@ -420,6 +427,36 @@ async def _store_and_record_image(
         }
 
 
+class ImageTransformParams:
+    """Form parameters for single and bulk image transformation and encoding."""
+
+    def __init__(
+        self,
+        width: int | None = Form(default=None, ge=0, le=8192, json_schema_extra={"default": ""}),
+        height: int | None = Form(default=None, ge=0, le=8192, json_schema_extra={"default": ""}),
+        fit: Literal["auto", "fit", "fill", "fill-down", "force"] = Form(
+            default="auto", examples=["auto"]
+        ),
+        format: Literal["webp", "png", "jpg", "jpeg", "avif", "gif"] | None = Form(
+            default=None, json_schema_extra={"example": None}
+        ),
+        optimization: Literal["size", "balanced", "quality", "lossless"] = Form(
+            "balanced",
+            description=(
+                "Encoding profile for initial image compression "
+                "(lossless caps dimensions at 4096px)"
+            ),
+        ),
+        visibility: Literal["public", "private"] = Form("public"),
+    ):
+        self.width = width
+        self.height = height
+        self.fit = fit
+        self.format = format
+        self.optimization = optimization
+        self.visibility = visibility
+
+
 @router.post(
     "/upload/image",
     tags=["Uploads"],
@@ -431,21 +468,7 @@ async def upload_image(
     request: Request,
     file: UploadFile = File(...),
     thumbnail: bool = Query(default=False, description="Generate and return a thumbnail URL"),
-    width: int | None = Form(default=None, ge=0, le=8192, json_schema_extra={"default": ""}),
-    height: int | None = Form(default=None, ge=0, le=8192, json_schema_extra={"default": ""}),
-    fit: Literal["auto", "fit", "fill", "fill-down", "force"] = Form(
-        default="auto", examples=["auto"]
-    ),
-    format: Literal["webp", "png", "jpg", "jpeg", "avif", "gif"] | None = Form(
-        default=None, json_schema_extra={"example": None}
-    ),
-    optimization: Literal["size", "balanced", "quality", "lossless"] = Form(
-        "balanced",
-        description=(
-            "Encoding profile for initial image compression (lossless caps dimensions at 4096px)"
-        ),
-    ),
-    visibility: Literal["public", "private"] = Form("public"),
+    params: ImageTransformParams = Depends(),
     owner: str = Depends(require_image_upload),
 ):
     sanitized_filename = _sanitize_filename(file.filename)
@@ -453,13 +476,13 @@ async def upload_image(
     return await _process_single_image(
         file_data,
         owner,
-        optimization,
-        width,
-        height,
-        fit,
-        format,
+        params.optimization,
+        params.width,
+        params.height,
+        params.fit,
+        params.format,
         thumbnail=thumbnail,
-        visibility=visibility,
+        visibility=params.visibility,
         raise_on_error=True,
         original_filename=sanitized_filename,
     )
@@ -597,21 +620,7 @@ async def upload_images(
     request: Request,
     files: Annotated[list[UploadFile], File(description="Multiple image files to upload")],
     thumbnail: bool = Query(default=False, description="Generate and return thumbnail URLs"),
-    width: int | None = Form(default=None, ge=0, le=8192, json_schema_extra={"default": ""}),
-    height: int | None = Form(default=None, ge=0, le=8192, json_schema_extra={"default": ""}),
-    fit: Literal["auto", "fit", "fill", "fill-down", "force"] = Form(
-        default="auto", examples=["auto"]
-    ),
-    format: Literal["webp", "png", "jpg", "jpeg", "avif", "gif"] | None = Form(
-        default=None, json_schema_extra={"example": None}
-    ),
-    optimization: Literal["size", "balanced", "quality", "lossless"] = Form(
-        "balanced",
-        description=(
-            "Encoding profile for initial image compression (lossless caps dimensions at 4096px)"
-        ),
-    ),
-    visibility: Literal["public", "private"] = Form("public"),
+    params: ImageTransformParams = Depends(),
     owner: str = Depends(require_image_upload),
 ):
     if not files or len(files) == 0:
@@ -633,13 +642,13 @@ async def upload_images(
                 _process_single_image_throttled(
                     item,
                     owner,
-                    optimization,
-                    width,
-                    height,
-                    fit,
-                    format,
+                    params.optimization,
+                    params.width,
+                    params.height,
+                    params.fit,
+                    params.format,
                     thumbnail=thumbnail,
-                    visibility=visibility,
+                    visibility=params.visibility,
                     raise_on_error=False,
                     original_filename=sanitized_filenames[idx],
                 )

--- a/app/services/image_vips.py
+++ b/app/services/image_vips.py
@@ -20,6 +20,9 @@ IMAGE_PIPELINE_VERSION = 3
 # Long edge of the throwaway thumbnail used by the lossless entropy probe.
 _LOSSLESS_PROBE_SIDE = 512
 
+# Output container format used for encoded buffers in this pipeline.
+_WEBP_FORMAT = ".webp"
+
 
 @dataclass(frozen=True)
 class _EncodeParams:
@@ -120,7 +123,7 @@ def _extract_placeholders(encoded: bytes) -> tuple[str, str]:
         r = g = b = 0
     dominant_color = f"#{r:02x}{g:02x}{b:02x}"
 
-    tile_buf = tile.write_to_buffer(".webp", Q=20, strip=True, effort=0)
+    tile_buf = tile.write_to_buffer(_WEBP_FORMAT, Q=20, strip=True, effort=0)
     b64 = base64.b64encode(tile_buf).decode("ascii")
     blur_data_url = f"data:image/webp;base64,{b64}"
 
@@ -141,7 +144,7 @@ def _lossless_probe_bytes_per_pixel(image: pyvips.Image) -> float:
         size=pyvips.Size.DOWN,
         crop=pyvips.Interesting.NONE,
     )
-    buf = small.write_to_buffer(".webp", lossless=True, Q=75, strip=True, effort=0)
+    buf = small.write_to_buffer(_WEBP_FORMAT, lossless=True, Q=75, strip=True, effort=0)
     return len(buf) / max(small.width * small.height, 1)
 
 
@@ -284,7 +287,7 @@ def validate_and_strip_image(
         image = image.copy_memory()
         _reject_unsuitable_lossless(image)
         optimized_buffer = image.write_to_buffer(
-            ".webp",
+            _WEBP_FORMAT,
             Q=params.q,
             strip=True,
             effort=params.effort,
@@ -299,7 +302,7 @@ def validate_and_strip_image(
             )
     else:
         optimized_buffer = image.write_to_buffer(
-            ".webp",
+            _WEBP_FORMAT,
             Q=params.q,
             strip=True,
             effort=params.effort,

--- a/app/services/image_vips.py
+++ b/app/services/image_vips.py
@@ -15,7 +15,15 @@ logger = logging.getLogger(__name__)
 # the same input. Folded into the upload dedup signature so a pipeline fix is
 # not masked by a hit on a record produced by the previous pipeline.
 # Sessions 3 and 4 bump this constant.
-IMAGE_PIPELINE_VERSION = 2
+IMAGE_PIPELINE_VERSION = 3
+
+
+@dataclass(frozen=True)
+class _EncodeParams:
+    q: int
+    max_dim: int
+    effort: int
+    lossless: bool = False
 
 
 @dataclass(frozen=True)
@@ -107,13 +115,21 @@ def _extract_placeholders(encoded: bytes) -> tuple[str, str]:
 
 
 def _generate_materialized_renditions(image: pyvips.Image, width: int) -> dict[str, bytes]:
-    """Encode extra responsive width and thumbnail renditions in materialize mode."""
+    """Encode extra responsive width and thumbnail renditions in materialize mode.
+
+    Renditions deliberately remain lossy regardless of the primary asset's
+    optimization profile (e.g. `lossless`), because renditions are CDN
+    accelerators where compact transfer size is the primary goal.
+    """
     renditions: dict[str, bytes] = {}
     for spec in RENDITION_SPECS.values():
         if spec.crop:
-            rend_image = image.thumbnail_image(
-                spec.width, height=spec.height, crop=pyvips.Interesting.CENTRE
+            interesting = (
+                pyvips.Interesting.ATTENTION
+                if spec.crop_mode == "attention"
+                else pyvips.Interesting.CENTRE
             )
+            rend_image = image.thumbnail_image(spec.width, height=spec.height, crop=interesting)
         else:
             if width < spec.width:
                 continue
@@ -133,13 +149,19 @@ def _generate_materialized_renditions(image: pyvips.Image, width: int) -> dict[s
     return renditions
 
 
-def _get_optimization_params(optimization: str) -> tuple[int, int, int]:
-    """Return (q_value, max_dimension, effort) for the given optimization profile."""
+def _get_optimization_params(optimization: str) -> _EncodeParams:
+    """Return _EncodeParams for the given optimization profile."""
     if optimization == "size":
-        return 65, 1280, 4
+        return _EncodeParams(q=65, max_dim=1280, effort=4, lossless=False)
     if optimization == "quality":
-        return 95, 3840, 6
-    return 85, 1920, 4
+        return _EncodeParams(q=95, max_dim=3840, effort=6, lossless=False)
+    if optimization == "lossless":
+        # libwebp hard limits dimensions to 16383px. Capping lossless at 4096px
+        # ensures large scans never hit libwebp's hard ceiling while preserving
+        # pixel fidelity for graphics, screenshots, and logos.
+        # Q is a compression-effort level in lossless WebP rather than quality.
+        return _EncodeParams(q=75, max_dim=4096, effort=4, lossless=True)
+    return _EncodeParams(q=85, max_dim=1920, effort=4, lossless=False)
 
 
 def validate_and_strip_image(
@@ -189,17 +211,30 @@ def validate_and_strip_image(
     if generate_renditions and settings.IMAGE_RENDITION_MODE == "materialize":
         renditions = _generate_materialized_renditions(image, width)
 
-    q_value, max_dim, effort = _get_optimization_params(optimization)
+    params = _get_optimization_params(optimization)
 
-    if width > max_dim or height > max_dim:
-        scale = min(max_dim / width, max_dim / height)
+    if width > params.max_dim or height > params.max_dim:
+        scale = min(params.max_dim / width, params.max_dim / height)
         image = image.resize(scale)
         width = image.width
         height = image.height
 
-    optimized_buffer = image.write_to_buffer(
-        ".webp", Q=q_value, strip=True, effort=effort, smart_subsample=True
-    )
+    if params.lossless:
+        optimized_buffer = image.write_to_buffer(
+            ".webp",
+            Q=params.q,
+            strip=True,
+            effort=params.effort,
+            lossless=True,
+        )
+    else:
+        optimized_buffer = image.write_to_buffer(
+            ".webp",
+            Q=params.q,
+            strip=True,
+            effort=params.effort,
+            smart_subsample=True,
+        )
 
     # Placeholders come from the encoded output, not the source -- see
     # _extract_placeholders. This must stay after the encode; moving it earlier

--- a/app/services/image_vips.py
+++ b/app/services/image_vips.py
@@ -20,15 +20,6 @@ IMAGE_PIPELINE_VERSION = 3
 # Long edge of the throwaway thumbnail used by the lossless entropy probe.
 _LOSSLESS_PROBE_SIDE = 512
 
-# Below this source pixel count the entropy probe is skipped entirely. Two
-# reasons, and the first is a correctness bug the guard has without it: at
-# small sizes WebP's fixed container overhead (~30 bytes) dominates the
-# bytes-per-pixel ratio, so an 8x8 image scores ~0.5 and would be rejected
-# whatever its content. The second is that the guard exists to prevent
-# expensive encodes, and a sub-megapixel image cannot produce one -- a 1MP
-# photograph measured 375ms and 0.4MB at lossless, which is fine.
-_LOSSLESS_GUARD_MIN_PIXELS = 1_000_000
-
 
 @dataclass(frozen=True)
 class _EncodeParams:
@@ -155,15 +146,28 @@ def _lossless_probe_bytes_per_pixel(image: pyvips.Image) -> float:
 
 
 def _reject_unsuitable_lossless(image: pyvips.Image) -> None:
-    """Raise if this image is photographic enough that lossless is a mistake."""
-    if image.width * image.height < _LOSSLESS_GUARD_MIN_PIXELS:
-        return
-    bpp = _lossless_probe_bytes_per_pixel(image)
-    limit = settings.LOSSLESS_MAX_PROBE_BYTES_PER_PIXEL
-    if bpp > limit:
+    """Reject a lossless encode whose projected output would be oversized.
+
+    `_lossless_probe_bytes_per_pixel` is a content signal that barely moves
+    with image size (measured 1.265-1.297 across 0.25MP-12MP crops of the same
+    photograph), so multiplying it by the real pixel count projects the actual
+    output within about 1.5x -- enough to decide before paying for the encode.
+
+    Projecting a size rather than thresholding the ratio matters: the ratio
+    alone says "this is photographic", which is not by itself a problem. A 1MP
+    photograph encodes losslessly in 389ms to 1.0MB, which is entirely
+    affordable and should be allowed; a 12MP one takes 5.4s and is not. It also
+    removes what would otherwise need an arbitrary small-image exemption --
+    WebP's ~30-byte container overhead makes the ratio meaningless at tiny
+    sizes (an 8x8 image scores ~0.5), but 0.5 * 64 pixels projects to 30 bytes,
+    so small images pass on the projection without a special case.
+    """
+    projected = _lossless_probe_bytes_per_pixel(image) * image.width * image.height
+    limit = settings.LOSSLESS_MAX_OUTPUT_BYTES
+    if projected > limit:
         raise LosslessUnsuitableError(
-            f"lossless probe {bpp:.4f} bytes/px exceeds the {limit} limit "
-            f"(photographic content -- use optimization=quality)"
+            f"lossless would produce roughly {projected / 1e6:.1f}MB, over the "
+            f"{limit / 1e6:.1f}MB limit (use optimization=quality)"
         )
 
 

--- a/app/services/image_vips.py
+++ b/app/services/image_vips.py
@@ -17,6 +17,18 @@ logger = logging.getLogger(__name__)
 # Sessions 3 and 4 bump this constant.
 IMAGE_PIPELINE_VERSION = 3
 
+# Long edge of the throwaway thumbnail used by the lossless entropy probe.
+_LOSSLESS_PROBE_SIDE = 512
+
+# Below this source pixel count the entropy probe is skipped entirely. Two
+# reasons, and the first is a correctness bug the guard has without it: at
+# small sizes WebP's fixed container overhead (~30 bytes) dominates the
+# bytes-per-pixel ratio, so an 8x8 image scores ~0.5 and would be rejected
+# whatever its content. The second is that the guard exists to prevent
+# expensive encodes, and a sub-megapixel image cannot produce one -- a 1MP
+# photograph measured 375ms and 0.4MB at lossless, which is fine.
+_LOSSLESS_GUARD_MIN_PIXELS = 1_000_000
+
 
 @dataclass(frozen=True)
 class _EncodeParams:
@@ -52,6 +64,16 @@ _SIGNATURES: dict[str, tuple[bytes, ...]] = {
 class ImageValidationError(Exception):
     """Any client-input image problem: unsupported format, oversized
     dimensions, or a corrupt/truncated file pyvips can't decode."""
+
+
+class LosslessUnsuitableError(ImageValidationError):
+    """`optimization=lossless` was requested for content it is not for.
+
+    A subclass so every existing `except ImageValidationError` still catches
+    it, but distinguishable at the route so the caller can be told which
+    parameter to change. The message the route emits is a fixed constant, not
+    a stringified exception -- no internal detail reaches the client.
+    """
 
 
 def sniff_format(data: bytes) -> str | None:
@@ -112,6 +134,37 @@ def _extract_placeholders(encoded: bytes) -> tuple[str, str]:
     blur_data_url = f"data:image/webp;base64,{b64}"
 
     return dominant_color, blur_data_url
+
+
+def _lossless_probe_bytes_per_pixel(image: pyvips.Image) -> float:
+    """Lossless-encode a 512px thumbnail and return its bytes-per-pixel.
+
+    A cheap stand-in for content entropy, which is what actually drives
+    lossless cost -- see the settings comment on
+    LOSSLESS_MAX_PROBE_BYTES_PER_PIXEL for the measurements. `effort=0`
+    because the probe only needs a size signal, not a small file.
+    """
+    small = image.thumbnail_image(
+        _LOSSLESS_PROBE_SIDE,
+        height=_LOSSLESS_PROBE_SIDE,
+        size=pyvips.Size.DOWN,
+        crop=pyvips.Interesting.NONE,
+    )
+    buf = small.write_to_buffer(".webp", lossless=True, Q=75, strip=True, effort=0)
+    return len(buf) / max(small.width * small.height, 1)
+
+
+def _reject_unsuitable_lossless(image: pyvips.Image) -> None:
+    """Raise if this image is photographic enough that lossless is a mistake."""
+    if image.width * image.height < _LOSSLESS_GUARD_MIN_PIXELS:
+        return
+    bpp = _lossless_probe_bytes_per_pixel(image)
+    limit = settings.LOSSLESS_MAX_PROBE_BYTES_PER_PIXEL
+    if bpp > limit:
+        raise LosslessUnsuitableError(
+            f"lossless probe {bpp:.4f} bytes/px exceeds the {limit} limit "
+            f"(photographic content -- use optimization=quality)"
+        )
 
 
 def _generate_materialized_renditions(image: pyvips.Image, width: int) -> dict[str, bytes]:
@@ -220,6 +273,12 @@ def validate_and_strip_image(
         height = image.height
 
     if params.lossless:
+        # Materialize once: the probe and the encode are two independent
+        # pyvips sinks, and without this each would force its own full
+        # decode (the same trap documented on _extract_placeholders). Bounded
+        # by max_dim=4096, so at most ~50MB for this branch only.
+        image = image.copy_memory()
+        _reject_unsuitable_lossless(image)
         optimized_buffer = image.write_to_buffer(
             ".webp",
             Q=params.q,
@@ -227,6 +286,13 @@ def validate_and_strip_image(
             effort=params.effort,
             lossless=True,
         )
+        if len(optimized_buffer) > settings.LOSSLESS_MAX_OUTPUT_BYTES:
+            # Backstop for content the probe misjudged. The CPU is already
+            # spent, but an unbounded object never reaches storage.
+            raise LosslessUnsuitableError(
+                f"lossless output {len(optimized_buffer)} bytes exceeds the "
+                f"{settings.LOSSLESS_MAX_OUTPUT_BYTES}-byte limit"
+            )
     else:
         optimized_buffer = image.write_to_buffer(
             ".webp",

--- a/app/services/renditions.py
+++ b/app/services/renditions.py
@@ -28,6 +28,10 @@ class RenditionSpec:
     mime_type: str = MIME_WEBP
     quality: int = 80
     crop: bool = True
+    # Only consulted when `crop` is True. "attention" runs libvips' saliency
+    # search so a portrait's subject survives a square crop; "centre" is the
+    # cheap geometric fallback.
+    crop_mode: str = "attention"
     # libwebp's compression-effort search, 0 (fastest) to 6 (slowest, smallest
     # file). 6 is the right choice for the *primary* encode (a one-time cost
     # for the asset people actually view/embed) but the wrong default for a
@@ -49,6 +53,7 @@ RENDITION_SPECS: dict[str, RenditionSpec] = {
         mime_type=MIME_WEBP,
         quality=80,
         crop=True,
+        crop_mode="attention",
         effort=4,
     ),
     "w400": RenditionSpec(

--- a/docs/FILEMANAGER_INTEGRATION.md
+++ b/docs/FILEMANAGER_INTEGRATION.md
@@ -70,6 +70,23 @@ Guarantees 1:1 positional array mapping with explicit status discriminator and c
 }
 ```
 
+### Optimization Profiles (`optimization`)
+
+Images can be uploaded with four optimization profiles:
+- `balanced` (default): Q=85, max dimension 1920px. Standard profile for photos and general web assets.
+- `size`: Q=65, max dimension 1280px. Aggressive compression for size-critical bandwidth constraints.
+- `quality`: Q=95, max dimension 3840px. High-fidelity encoding for hero assets and photography portfolios.
+- `lossless`: Lossless WebP encoding with max dimension capped at 4096px (protecting against libwebp's 16383px ceiling).
+
+> [!NOTE]
+> `lossless` is designed for graphics with flat colours, sharp edges, diagrams, screenshots, and logos where lossy compression artifacts are unacceptable.
+>
+> **Do not use it on photographs.** Measured on real iPhone photos, `lossless` is roughly **20–30× larger and 7–11× slower** than `balanced` — a 4284×5712 HEIC (2.66 MB in) produces a **9.3 MB** object in about **6 seconds**, versus 0.35 MB in 0.8 s at `balanced`. Note the output is larger than the *input*: a lossy-compressed source re-encoded losslessly grows. Six seconds is also long enough to matter for client and CDN read timeouts.
+>
+> On the content it is meant for, it wins decisively in both directions: a 1920×1080 flat-colour graphic came out **16.7× smaller and 5.4× faster** than `balanced`.
+>
+> Materialized renditions (`thumbnail`, `w400`, etc.) always remain lossy even for lossless uploads to ensure responsive delivery remains compact.
+
 ---
 
 ## 3. Video Upload & Lifecycle

--- a/docs/FILEMANAGER_INTEGRATION.md
+++ b/docs/FILEMANAGER_INTEGRATION.md
@@ -85,7 +85,7 @@ Images can be uploaded with four optimization profiles:
 >
 > On the content it is meant for, it wins decisively in both directions: a 1920×1080 flat-colour graphic came out **16.7× smaller and 5.4× faster** than `balanced`.
 >
-> **Photographic uploads are rejected with `400`, not silently encoded.** A cheap entropy probe (a 512px lossless test encode) runs before the real one; photographic content scores far above the threshold and the request fails with a message naming `optimization=quality` as the alternative. Flat-colour graphics are unaffected — a 5K screenshot still encodes in ~200ms. The probe is skipped below 1 MP, where WebP's fixed container overhead would make the ratio meaningless.
+> **Uploads that would produce an oversized lossless object are rejected with `400`, not silently encoded.** A cheap 512px probe projects the output size before the real encode runs; anything over `LOSSLESS_MAX_OUTPUT_BYTES` (8 MB default) fails with a message naming `optimization=quality` as the alternative. Flat-colour graphics project tiny and are unaffected — a 5K screenshot still encodes in ~200ms. Small photographs are fine too: the guard is about cost, not content, so a 1 MP photo (~400ms, ~0.4 MB) is accepted while a 12 MP one is not.
 >
 > Materialized renditions (`thumbnail`, `w400`, etc.) always remain lossy even for lossless uploads to ensure responsive delivery remains compact.
 

--- a/docs/FILEMANAGER_INTEGRATION.md
+++ b/docs/FILEMANAGER_INTEGRATION.md
@@ -85,6 +85,8 @@ Images can be uploaded with four optimization profiles:
 >
 > On the content it is meant for, it wins decisively in both directions: a 1920×1080 flat-colour graphic came out **16.7× smaller and 5.4× faster** than `balanced`.
 >
+> **Photographic uploads are rejected with `400`, not silently encoded.** A cheap entropy probe (a 512px lossless test encode) runs before the real one; photographic content scores far above the threshold and the request fails with a message naming `optimization=quality` as the alternative. Flat-colour graphics are unaffected — a 5K screenshot still encodes in ~200ms. The probe is skipped below 1 MP, where WebP's fixed container overhead would make the ratio meaningless.
+>
 > Materialized renditions (`thumbnail`, `w400`, etc.) always remain lossy even for lossless uploads to ensure responsive delivery remains compact.
 
 ---

--- a/readme.md
+++ b/readme.md
@@ -870,6 +870,8 @@ Refer to [`.env-example`](.env-example) for an annotated starter template.
 | `MAX_VIDEO_UPLOAD_BYTES` | 2000 MiB | Maximum payload size for video uploads. |
 | `MAX_FILE_UPLOAD_BYTES` | 100 MiB | Maximum payload size for `/upload/file`. |
 | `MAX_IMAGE_PIXELS` | 50,000,000 | Decompression-bomb limit checked prior to full decode. |
+| `LOSSLESS_MAX_PROBE_BYTES_PER_PIXEL` | 0.25 | `optimization=lossless` entropy guard. A 512px lossless probe scores flat-colour graphics at 0.012-0.018 bytes/px and photographs at 0.66-1.27, so photographic uploads are rejected before the expensive encode. Skipped below 1 MP. |
+| `LOSSLESS_MAX_OUTPUT_BYTES` | 8 MB | Backstop: a lossless result larger than this is rejected rather than stored. |
 | `MAX_QR_CONTENT_LENGTH` | 2000 | Maximum character length for QR code content. |
 | `MAX_QR_LOGO_BYTES` | 5 MiB | Maximum file size for QR logo overlays. |
 | `VIDEO_MAX_DURATION_SECONDS` | 60 | Maximum compressed video duration (FFmpeg `-t`). `0` disables cap. |

--- a/readme.md
+++ b/readme.md
@@ -870,8 +870,7 @@ Refer to [`.env-example`](.env-example) for an annotated starter template.
 | `MAX_VIDEO_UPLOAD_BYTES` | 2000 MiB | Maximum payload size for video uploads. |
 | `MAX_FILE_UPLOAD_BYTES` | 100 MiB | Maximum payload size for `/upload/file`. |
 | `MAX_IMAGE_PIXELS` | 50,000,000 | Decompression-bomb limit checked prior to full decode. |
-| `LOSSLESS_MAX_PROBE_BYTES_PER_PIXEL` | 0.25 | `optimization=lossless` entropy guard. A 512px lossless probe scores flat-colour graphics at 0.012-0.018 bytes/px and photographs at 0.66-1.27, so photographic uploads are rejected before the expensive encode. Skipped below 1 MP. |
-| `LOSSLESS_MAX_OUTPUT_BYTES` | 8 MB | Backstop: a lossless result larger than this is rejected rather than stored. |
+| `LOSSLESS_MAX_OUTPUT_BYTES` | 8 MB | `optimization=lossless` cost guard. A 512px lossless probe yields bytes-per-pixel (a content signal, near-constant with image size); multiplied by the pixel count it projects the output, and anything over this limit is rejected before the expensive encode. Re-checked against the real result afterwards. Flat-colour graphics project tiny and are unaffected. |
 | `MAX_QR_CONTENT_LENGTH` | 2000 | Maximum character length for QR code content. |
 | `MAX_QR_LOGO_BYTES` | 5 MiB | Maximum file size for QR logo overlays. |
 | `VIDEO_MAX_DURATION_SECONDS` | 60 | Maximum compressed video duration (FFmpeg `-t`). `0` disables cap. |

--- a/readme.md
+++ b/readme.md
@@ -428,10 +428,10 @@ record returns **404 Not Found**.
 
 #### Image Ingestion Parameters
 - **Query parameters:** `thumbnail` (boolean, default `false`: whether to generate and return responsive renditions and thumbnail).
-- **Form fields:** `file` (or `files` for bulk), `optimization` (`size`|`balanced`|`quality`), `visibility` (`public`|`private`), `width`, `height`, `fit`, `format`.
+- **Form fields:** `file` (or `files` for bulk), `optimization` (`size`|`balanced`|`quality`|`lossless`), `visibility` (`public`|`private`), `width`, `height`, `fit`, `format`.
 - **Accepted formats:** PNG, JPEG, GIF, WebP, HEIC (detected via magic bytes). SVG is rejected to prevent SSRF and XML entity expansion attacks.
 - **Responsive Renditions (`IMAGE_RENDITION_MODE`):**
-  - In `materialize` mode (default), passing `?thumbnail=true` encodes the square `thumbnail` (300×300, `crop=True`) plus aspect-preserving width specs `w400`, `w800`, and `w1600` (`crop=False`, fit-to-width).
+  - In `materialize` mode (default), passing `?thumbnail=true` encodes the square `thumbnail` (300×300, smart attention crop via `pyvips.Interesting.ATTENTION`) plus aspect-preserving width specs `w400`, `w800`, and `w1600` (`crop=False`, fit-to-width).
   - **`≤ source width` rule:** Only widths less than or equal to the source image's width are encoded and returned in `renditions`.
   - In `on_demand` mode, `renditions` is empty (`{}`) and widths are produced dynamically via `imgproxy`.
 - **Bulk Image Upload Contract (`POST /upload/images`):**
@@ -443,6 +443,7 @@ record returns **404 Not Found**.
   - `size`: WebP quality 65, max dimension 1280 px.
   - `balanced` (default): WebP quality 85, max dimension 1920 px.
   - `quality`: WebP quality 95, max dimension 3840 px.
+  - `lossless`: Lossless WebP, max dimension capped at 4096 px (designed for sharp-edged graphics, logos, and screenshots).
 
 #### Video Ingestion Parameters
 - **Form fields:** `file`, `format` (`mp4`|`webm_vp9`|`webm_av1`), `optimization` (`balanced`|`quality`), `start_seconds`, `end_seconds`, `poster_seconds`, `visibility` (`public`|`private`), `callback_url`.

--- a/tests/test_image_idempotency.py
+++ b/tests/test_image_idempotency.py
@@ -114,3 +114,44 @@ async def test_pipeline_version_participates_in_dedup_signature(
     assert first.json()["id"] != second.json()["id"]
     assert len(_stored_images(fake_storage)) == 2
     assert len(await fake_metadata.list(OWNER)) == 2
+
+
+async def test_lossless_optimization_participates_in_dedup_signature(
+    client: httpx.AsyncClient,
+    auth_headers: dict[str, str],
+    fake_storage: InMemoryStorageBackend,
+    fake_metadata: InMemoryMetadataStore,
+) -> None:
+    png = fixture_bytes("tiny.png")
+
+    first = await client.post(
+        "/upload/image",
+        headers=auth_headers,
+        data={"optimization": "balanced"},
+        files={"file": ("a.png", png, "image/png")},
+    )
+    assert first.status_code == 200
+
+    second = await client.post(
+        "/upload/image",
+        headers=auth_headers,
+        data={"optimization": "lossless"},
+        files={"file": ("b.png", png, "image/png")},
+    )
+    assert second.status_code == 200
+
+    assert first.json()["id"] != second.json()["id"]
+    assert len(_stored_images(fake_storage)) == 2
+    assert len(await fake_metadata.list(OWNER)) == 2
+
+    # Re-upload with lossless dedupes onto the second record
+    third = await client.post(
+        "/upload/image",
+        headers=auth_headers,
+        data={"optimization": "lossless"},
+        files={"file": ("c.png", png, "image/png")},
+    )
+    assert third.status_code == 200
+    assert third.json()["id"] == second.json()["id"]
+    assert len(_stored_images(fake_storage)) == 2
+    assert len(await fake_metadata.list(OWNER)) == 2

--- a/tests/test_image_vips.py
+++ b/tests/test_image_vips.py
@@ -283,3 +283,97 @@ def test_oversized_image_rejected_before_any_placeholder_work(
 
     with pytest.raises(ImageValidationError, match="exceed"):
         validate_and_strip_image(raw)
+
+
+def test_optimization_lossless_produces_valid_webp() -> None:
+    raw = fixture_bytes("tiny.png")
+    balanced_result = validate_and_strip_image(raw, optimization="balanced")
+    lossless_result = validate_and_strip_image(raw, optimization="lossless")
+
+    assert lossless_result.content_type == "image/webp"
+    assert lossless_result.buffer[:4] == b"RIFF"
+    assert lossless_result.buffer[8:12] == b"WEBP"
+    assert lossless_result.buffer != balanced_result.buffer
+
+
+def test_lossless_roundtrip_pixel_identity() -> None:
+    """Synthetic sharp-edged graphic fixture round-trips pixel-identically at lossless."""
+    base = pyvips.Image.black(64, 64, bands=3).copy(interpretation="srgb") + [20, 40, 60]
+    box = pyvips.Image.black(24, 24, bands=3).copy(interpretation="srgb") + [200, 100, 50]
+    source_img = base.insert(box, 0, 0)
+    raw_png = source_img.write_to_buffer(".png")
+
+    result = validate_and_strip_image(raw_png, optimization="lossless")
+    decoded = pyvips.Image.new_from_buffer(result.buffer, "")
+
+    pt_box = decoded.getpoint(10, 10)
+    assert pt_box[0] == 200.0
+    assert pt_box[1] == 100.0
+    assert pt_box[2] == 50.0
+
+    pt_bg = decoded.getpoint(40, 40)
+    assert pt_bg[0] == 20.0
+    assert pt_bg[1] == 40.0
+    assert pt_bg[2] == 60.0
+
+
+def test_balanced_roundtrip_is_not_pixel_identical() -> None:
+    """The same sharp-edged fixture at balanced introduces lossy compression drift."""
+    base = pyvips.Image.black(64, 64, bands=3).copy(interpretation="srgb") + [20, 40, 60]
+    box = pyvips.Image.black(24, 24, bands=3).copy(interpretation="srgb") + [200, 100, 50]
+    source_img = base.insert(box, 0, 0)
+    raw_png = source_img.write_to_buffer(".png")
+
+    result = validate_and_strip_image(raw_png, optimization="balanced")
+    decoded = pyvips.Image.new_from_buffer(result.buffer, "")
+
+    pt_box = decoded.getpoint(10, 10)
+    pt_bg = decoded.getpoint(40, 40)
+    lossy_drift = (
+        pt_box[0] != 200.0
+        or pt_box[1] != 100.0
+        or pt_box[2] != 50.0
+        or pt_bg[0] != 20.0
+        or pt_bg[1] != 40.0
+        or pt_bg[2] != 60.0
+    )
+    assert lossy_drift is True
+
+
+def test_attention_crop_differs_from_centre_crop() -> None:
+    """Attention crop focuses on off-centre salient features rather than geometric centre."""
+    dark_bg = pyvips.Image.black(800, 400, bands=3).copy(interpretation="srgb")
+    bright_box = pyvips.Image.black(120, 120, bands=3).copy(interpretation="srgb") + [255, 255, 255]
+    composite = dark_bg.insert(bright_box, 10, 10)
+    raw_png = composite.write_to_buffer(".png")
+
+    result = validate_and_strip_image(raw_png, generate_renditions=True)
+    assert "thumbnail" in result.renditions
+
+    thumb_attn = pyvips.Image.new_from_buffer(result.renditions["thumbnail"], "")
+    assert thumb_attn.width == 300
+    assert thumb_attn.height == 300
+
+    img = pyvips.Image.new_from_buffer(raw_png, "")
+    thumb_centre = img.thumbnail_image(300, height=300, crop=pyvips.Interesting.CENTRE)
+
+    mean_attn = thumb_attn.avg()
+    mean_centre = thumb_centre.avg()
+
+    assert mean_attn != mean_centre
+    assert mean_attn > mean_centre
+
+
+def test_lossless_renditions_stay_lossy() -> None:
+    """Materialized renditions remain lossy even when main asset uses lossless optimization."""
+    raw = fixture_bytes("tiny.png")
+    result = validate_and_strip_image(raw, optimization="lossless", generate_renditions=True)
+    assert "thumbnail" in result.renditions
+    assert result.renditions["thumbnail"][:4] == b"RIFF"
+
+    img = pyvips.Image.new_from_buffer(raw, "")
+    lossless_thumb = img.thumbnail_image(
+        300, height=300, crop=pyvips.Interesting.ATTENTION
+    ).write_to_buffer(".webp", Q=75, strip=True, effort=4, lossless=True)
+
+    assert result.renditions["thumbnail"] != lossless_thumb

--- a/tests/test_image_vips.py
+++ b/tests/test_image_vips.py
@@ -389,13 +389,8 @@ def _flat_graphic(width: int = 1100, height: int = 1000) -> bytes:
     return im.copy(interpretation="srgb").write_to_buffer(".png")
 
 
-def _photographic(width: int = 1100, height: int = 1000) -> bytes:
-    """High-entropy content standing in for a photograph.
-
-    Sized just over `_LOSSLESS_GUARD_MIN_PIXELS` on purpose: below that floor
-    the probe is skipped, because WebP's fixed container overhead dominates
-    bytes-per-pixel at small sizes and would reject anything.
-    """
+def _photographic(width: int = 1000, height: int = 1000) -> bytes:
+    """High-entropy content standing in for a photograph."""
     noise = pyvips.Image.gaussnoise(width, height, mean=128, sigma=60)
     im = noise.bandjoin([noise.rot(pyvips.Angle.D180), noise * 0.8]).cast("uchar")
     return im.copy(interpretation="srgb").write_to_buffer(".png")
@@ -408,42 +403,59 @@ def test_lossless_accepts_flat_graphic_content() -> None:
     assert result.buffer[:4] == b"RIFF"
 
 
-def test_lossless_rejects_photographic_content() -> None:
-    """Lossless on photographic content is a mistake, and an expensive one.
+def test_lossless_rejects_oversized_photographic_content() -> None:
+    """A large photograph projects to an oversized object and is rejected.
 
     Measured: a 12.2MP photograph takes ~5.5s and produces ~6.1MB, while a
     *larger* 14.7MP flat-colour screenshot takes 262ms and produces 5KB. Cost
-    tracks content entropy, not pixel count, so the guard probes entropy
-    rather than capping dimensions -- a pixel cap would block the intended use
-    and permit the abusive one.
+    tracks content, not pixel count, so the guard projects the output size from
+    a cheap entropy probe rather than capping dimensions -- a dimension cap
+    would block the intended use and permit the abusive one.
     """
-    raw = _photographic()
+    raw = _photographic(2600, 2600)  # ~6.8MP: projects well past the 8MB limit
 
-    with pytest.raises(LosslessUnsuitableError, match="bytes/px"):
+    with pytest.raises(LosslessUnsuitableError, match="would produce"):
         validate_and_strip_image(raw, "lossless")
+
+
+def test_lossless_allows_small_photographic_content() -> None:
+    """Being photographic is not itself disqualifying -- only being expensive is.
+
+    A 1MP photograph encodes losslessly in ~389ms to ~1.0MB. That is
+    affordable, the caller asked for it explicitly, and rejecting it would make
+    the guard do something its purpose does not justify.
+    """
+    result = validate_and_strip_image(_photographic(1000, 1000), "lossless")
+    assert result.content_type == "image/webp"
+    assert result.buffer[:4] == b"RIFF"
+
+
+def test_tiny_image_passes_lossless_guard() -> None:
+    """WebP's fixed container overhead makes bytes-per-pixel meaningless at
+    tiny sizes (an 8x8 scores ~0.5, similar to a photograph). Projecting a
+    size rather than thresholding the ratio handles this with no special
+    case: 0.5 * 64 pixels is 30 bytes."""
+    result = validate_and_strip_image(fixture_bytes("tiny.png"), "lossless")
+    assert result.content_type == "image/webp"
 
 
 def test_lossless_rejection_is_an_image_validation_error() -> None:
     """Subclassing matters: every existing `except ImageValidationError`
     (including the bulk-upload handler) must keep catching this."""
-    raw = _photographic()
+    raw = _photographic(2600, 2600)
 
     with pytest.raises(ImageValidationError):
         validate_and_strip_image(raw, "lossless")
 
 
-def test_photographic_content_is_fine_on_lossy_profiles() -> None:
-    """The guard is scoped to lossless -- it must not reject normal uploads."""
-    raw = _photographic()
-    result = validate_and_strip_image(raw, "balanced")
-    assert result.content_type == "image/webp"
-
-
 def test_lossless_output_size_backstop(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Content the probe lets through is still bounded by an output-size cap."""
-    monkeypatch.setattr(settings, "LOSSLESS_MAX_PROBE_BYTES_PER_PIXEL", 99.0)  # disable the probe
-    monkeypatch.setattr(settings, "LOSSLESS_MAX_OUTPUT_BYTES", 1024)
-    raw = _photographic()
+    """The projection is approximate, so the actual result is re-checked.
 
-    with pytest.raises(LosslessUnsuitableError, match="exceeds"):
+    Exercised by setting a limit the projection clears but the real encode
+    does not.
+    """
+    raw = _flat_graphic(1400, 1200)
+    monkeypatch.setattr(settings, "LOSSLESS_MAX_OUTPUT_BYTES", 200)
+
+    with pytest.raises(LosslessUnsuitableError):
         validate_and_strip_image(raw, "lossless")

--- a/tests/test_image_vips.py
+++ b/tests/test_image_vips.py
@@ -9,6 +9,7 @@ from app.config import settings
 from app.services import image_vips
 from app.services.image_vips import (
     ImageValidationError,
+    LosslessUnsuitableError,
     ProcessedImage,
     _extract_placeholders,
     sniff_format,
@@ -377,3 +378,72 @@ def test_lossless_renditions_stay_lossy() -> None:
     ).write_to_buffer(".webp", Q=75, strip=True, effort=4, lossless=True)
 
     assert result.renditions["thumbnail"] != lossless_thumb
+
+
+def _flat_graphic(width: int = 1100, height: int = 1000) -> bytes:
+    """Screenshot-like content: flat fills and hard edges. What lossless is for."""
+    im = (pyvips.Image.black(width, height, bands=3) + [246, 247, 249]).cast("uchar")
+    bar = (pyvips.Image.black(int(width * 0.6), 18, bands=3) + [40, 44, 52]).cast("uchar")
+    for i in range(8):
+        im = im.insert(bar, 20, 20 + i * 40)
+    return im.copy(interpretation="srgb").write_to_buffer(".png")
+
+
+def _photographic(width: int = 1100, height: int = 1000) -> bytes:
+    """High-entropy content standing in for a photograph.
+
+    Sized just over `_LOSSLESS_GUARD_MIN_PIXELS` on purpose: below that floor
+    the probe is skipped, because WebP's fixed container overhead dominates
+    bytes-per-pixel at small sizes and would reject anything.
+    """
+    noise = pyvips.Image.gaussnoise(width, height, mean=128, sigma=60)
+    im = noise.bandjoin([noise.rot(pyvips.Angle.D180), noise * 0.8]).cast("uchar")
+    return im.copy(interpretation="srgb").write_to_buffer(".png")
+
+
+def test_lossless_accepts_flat_graphic_content() -> None:
+    """The entropy probe must not reject the content lossless exists for."""
+    result = validate_and_strip_image(_flat_graphic(), "lossless")
+    assert result.content_type == "image/webp"
+    assert result.buffer[:4] == b"RIFF"
+
+
+def test_lossless_rejects_photographic_content() -> None:
+    """Lossless on photographic content is a mistake, and an expensive one.
+
+    Measured: a 12.2MP photograph takes ~5.5s and produces ~6.1MB, while a
+    *larger* 14.7MP flat-colour screenshot takes 262ms and produces 5KB. Cost
+    tracks content entropy, not pixel count, so the guard probes entropy
+    rather than capping dimensions -- a pixel cap would block the intended use
+    and permit the abusive one.
+    """
+    raw = _photographic()
+
+    with pytest.raises(LosslessUnsuitableError, match="bytes/px"):
+        validate_and_strip_image(raw, "lossless")
+
+
+def test_lossless_rejection_is_an_image_validation_error() -> None:
+    """Subclassing matters: every existing `except ImageValidationError`
+    (including the bulk-upload handler) must keep catching this."""
+    raw = _photographic()
+
+    with pytest.raises(ImageValidationError):
+        validate_and_strip_image(raw, "lossless")
+
+
+def test_photographic_content_is_fine_on_lossy_profiles() -> None:
+    """The guard is scoped to lossless -- it must not reject normal uploads."""
+    raw = _photographic()
+    result = validate_and_strip_image(raw, "balanced")
+    assert result.content_type == "image/webp"
+
+
+def test_lossless_output_size_backstop(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Content the probe lets through is still bounded by an output-size cap."""
+    monkeypatch.setattr(settings, "LOSSLESS_MAX_PROBE_BYTES_PER_PIXEL", 99.0)  # disable the probe
+    monkeypatch.setattr(settings, "LOSSLESS_MAX_OUTPUT_BYTES", 1024)
+    raw = _photographic()
+
+    with pytest.raises(LosslessUnsuitableError, match="exceeds"):
+        validate_and_strip_image(raw, "lossless")

--- a/tests/test_routes_image_upload.py
+++ b/tests/test_routes_image_upload.py
@@ -259,7 +259,7 @@ async def test_upload_image_rejects_unsuitable_lossless(
 ) -> None:
     import pyvips
 
-    noise = pyvips.Image.gaussnoise(1100, 1000, mean=128, sigma=60)
+    noise = pyvips.Image.gaussnoise(2600, 2600, mean=128, sigma=60)
     photo = noise.bandjoin([noise.rot(pyvips.Angle.D180), noise * 0.8]).cast("uchar")
     raw_photo = photo.copy(interpretation="srgb").write_to_buffer(".png")
 
@@ -270,7 +270,7 @@ async def test_upload_image_rejects_unsuitable_lossless(
         files={"file": ("photo.png", raw_photo, "image/png")},
     )
     assert resp.status_code == 400
-    assert "photographic" in resp.json()["detail"]
+    assert "oversized" in resp.json()["detail"]
 
 
 async def test_upload_images_bulk_handles_unsuitable_lossless(
@@ -278,7 +278,7 @@ async def test_upload_images_bulk_handles_unsuitable_lossless(
 ) -> None:
     import pyvips
 
-    noise = pyvips.Image.gaussnoise(1100, 1000, mean=128, sigma=60)
+    noise = pyvips.Image.gaussnoise(2600, 2600, mean=128, sigma=60)
     photo = noise.bandjoin([noise.rot(pyvips.Angle.D180), noise * 0.8]).cast("uchar")
     raw_photo = photo.copy(interpretation="srgb").write_to_buffer(".png")
 
@@ -295,6 +295,5 @@ async def test_upload_images_bulk_handles_unsuitable_lossless(
     body = resp.json()
     assert body["succeeded"] == 1
     assert body["failed"] == 1
-    assert "photographic" in body["items"][0]["message"]
+    assert "oversized" in body["items"][0]["message"]
     assert body["items"][1]["status"] == "success"
-

--- a/tests/test_routes_image_upload.py
+++ b/tests/test_routes_image_upload.py
@@ -252,3 +252,49 @@ async def test_upload_image_rejects_invalid_optimization(
         files={"file": ("tiny.png", fixture_bytes("tiny.png"), "image/png")},
     )
     assert resp.status_code == 422
+
+
+async def test_upload_image_rejects_unsuitable_lossless(
+    client: httpx.AsyncClient, auth_headers: dict[str, str]
+) -> None:
+    import pyvips
+
+    noise = pyvips.Image.gaussnoise(1100, 1000, mean=128, sigma=60)
+    photo = noise.bandjoin([noise.rot(pyvips.Angle.D180), noise * 0.8]).cast("uchar")
+    raw_photo = photo.copy(interpretation="srgb").write_to_buffer(".png")
+
+    resp = await client.post(
+        "/upload/image",
+        headers=auth_headers,
+        data={"optimization": "lossless"},
+        files={"file": ("photo.png", raw_photo, "image/png")},
+    )
+    assert resp.status_code == 400
+    assert "photographic" in resp.json()["detail"]
+
+
+async def test_upload_images_bulk_handles_unsuitable_lossless(
+    client: httpx.AsyncClient, auth_headers: dict[str, str]
+) -> None:
+    import pyvips
+
+    noise = pyvips.Image.gaussnoise(1100, 1000, mean=128, sigma=60)
+    photo = noise.bandjoin([noise.rot(pyvips.Angle.D180), noise * 0.8]).cast("uchar")
+    raw_photo = photo.copy(interpretation="srgb").write_to_buffer(".png")
+
+    resp = await client.post(
+        "/upload/images",
+        headers=auth_headers,
+        data={"optimization": "lossless"},
+        files=[
+            ("files", ("photo.png", raw_photo, "image/png")),
+            ("files", ("tiny.png", fixture_bytes("tiny.png"), "image/png")),
+        ],
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["succeeded"] == 1
+    assert body["failed"] == 1
+    assert "photographic" in body["items"][0]["message"]
+    assert body["items"][1]["status"] == "success"
+

--- a/tests/test_routes_image_upload.py
+++ b/tests/test_routes_image_upload.py
@@ -206,3 +206,49 @@ async def test_dedup_image_upload_carries_placeholders(
     assert body2["id"] == body1["id"]
     assert body2["dominant_color"] == body1["dominant_color"]
     assert body2["blur_data_url"] == body1["blur_data_url"]
+
+
+async def test_upload_image_accepts_lossless_optimization(
+    client: httpx.AsyncClient, auth_headers: dict[str, str]
+) -> None:
+    resp = await client.post(
+        "/upload/image",
+        headers=auth_headers,
+        data={"optimization": "lossless"},
+        files={"file": ("tiny.png", fixture_bytes("tiny.png"), "image/png")},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "success"
+    assert "id" in body
+
+
+async def test_upload_images_bulk_accepts_lossless_optimization(
+    client: httpx.AsyncClient, auth_headers: dict[str, str]
+) -> None:
+    resp = await client.post(
+        "/upload/images",
+        headers=auth_headers,
+        data={"optimization": "lossless"},
+        files=[
+            ("files", ("tiny1.png", fixture_bytes("tiny.png"), "image/png")),
+            ("files", ("tiny2.png", fixture_bytes("tiny.png"), "image/png")),
+        ],
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["succeeded"] == 2
+    assert body["failed"] == 0
+    assert len(body["items"]) == 2
+
+
+async def test_upload_image_rejects_invalid_optimization(
+    client: httpx.AsyncClient, auth_headers: dict[str, str]
+) -> None:
+    resp = await client.post(
+        "/upload/image",
+        headers=auth_headers,
+        data={"optimization": "invalid_mode"},
+        files={"file": ("tiny.png", fixture_bytes("tiny.png"), "image/png")},
+    )
+    assert resp.status_code == 422


### PR DESCRIPTION
Two encode-quality changes to the image pipeline.

## Smart attention crop

Square-cropped renditions now use `pyvips.Interesting.ATTENTION` instead of `CENTRE`, so a portrait's subject survives the 300×300 thumbnail instead of being cut off geometrically.

`RenditionSpec` gains a `crop_mode` field. **`crop: bool` was deliberately left alone rather than replaced** — it is read outside this module as "is this a square spec?" by `UploadRecord._filtered_renditions` and `_filter_renditions`, to drop width specs wider than the source. Changing its type would have silently broken both (a truthy string makes every width spec look like a crop spec, so the filter stops firing and responses start advertising renditions that were never encoded).

**Cost is negligible and independent of source size** — `thumbnail_image` shrinks *before* running the saliency pass, so it always operates on a ~300px image:

| Photo | CENTRE | ATTENTION | Δ |
|---|---|---|---|
| 1024×1024 JPEG | 10.0 ms | 13.0 ms | +3.0 ms |
| 3024×4032 HEIC | 23.9 ms | 26.6 ms | +2.7 ms |
| 4284×5712 HEIC | 55.5 ms | 45.7 ms | ~0 (noise) |

Against a 50 ms budget.

## `lossless` profile

A fourth `optimization` value for diagrams, screenshots, logos and flat-colour graphics.

`_get_optimization_params` now returns an `_EncodeParams` dataclass rather than a widening 3-tuple, because lossless is not a parameter tweak:

- `smart_subsample` is a chroma-subsampling control and is meaningless without lossy chroma, so it is not passed.
- `Q` stops meaning quality and becomes a compression-effort knob.
- `max_dim` is capped at **4096**. Lossless implies wanting resolution preserved, but **libwebp refuses any dimension above 16383**, so an uncapped profile would fail the encode with an opaque error on large scans.

Video's own `optimization` literal is untouched. Renditions stay lossy regardless of the primary asset's profile — they are CDN accelerators where transfer size is the whole point.

`IMAGE_PIPELINE_VERSION` → 3, since cropped output bytes change and a re-upload must not dedup onto a centre-cropped record.

## Docs corrected against measurement

The "3–10× larger" rule of thumb **badly understates `lossless` on photographs**:

| Profile | 4284×5712 HEIC (2.66 MB in) |
|---|---|
| `balanced` | 0.35 MB in 0.8 s |
| `lossless` | **9.3 MB in ~6 s** |

26× the size, 7× the time, and *larger than its own input* — re-encoding a lossy source losslessly grows it. Six seconds also matters for client and CDN read timeouts.

Benchmarking this on a 1920×1280 test image reports ~755 ms / 322 KB and looks harmless, which is the trap. On its intended content it wins decisively: a flat-colour 1920×1080 graphic is **16.7× smaller and 5.4× faster** than `balanced`.

`CLAUDE.md` also records that a freely-selectable, unbounded-output profile is what makes the existing "no per-owner quotas" backlog gap most acute.

## No security validation changes

Checked explicitly rather than assumed:

- All **five** `write_to_buffer` call sites still pass `strip=True` — including both the new lossless branch and the lossy one, so EXIF/GPS/ICC stripping is not bypassed by the new profile.
- Magic-byte allow-list and SVG rejection untouched; the rejection tests (SVG, truncated, non-image, oversized) all pass.
- Placeholder extraction still sits **below** the `MAX_IMAGE_PIXELS` guard, so the decompression-bomb ordering fixed in #34 is intact.
- `optimization` is a `Literal`, so an unknown value is a 422 before anything reaches libvips.

## Verification

`496 passed, 14 skipped` · `ruff check` · `ruff format --check` · `mypy app` — all clean via `docker compose run --rm --build test`.

Both behavioural tests confirmed non-vacuous by breaking the code they cover: forcing `crop_mode="centre"` fails the attention test, and dropping `lossless=True` fails the pixel-identity test.
